### PR TITLE
Suport for camel 3.0.0-M2 and 2.21.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ language: java
 
 script:
   - ./mvnw clean install -Dcamel2
+  - ./mvnw clean install -Dcamel2 -Dcamel2.version=2.21.0
   - ./mvnw clean install -Dcamel3

--- a/camel-k-adapter-camel-2/src/main/java/org/apache/camel/k/adapter/DefaultRegistry.java
+++ b/camel-k-adapter-camel-2/src/main/java/org/apache/camel/k/adapter/DefaultRegistry.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.k.adapter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import org.apache.camel.NoSuchBeanException;
+
+public class DefaultRegistry implements Registry {
+    private final ConcurrentMap<String, Object> registry;
+
+    public DefaultRegistry() {
+        this.registry = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void bind(String name, Object bean) {
+        this.registry.put(name, bean);
+    }
+
+    @Override
+    public Object lookupByName(String name) {
+        return registry.get(name);
+    }
+
+    @Override
+    public <T> T lookupByNameAndType(String name, Class<T> type) {
+        final Object answer = lookupByName(name);
+
+        if (answer != null) {
+            try {
+                return type.cast(answer);
+            } catch (Throwable t) {
+                throw new NoSuchBeanException(
+                    name,
+                    "Found bean: " + name + " in RuntimeRegistry: " + this + " of type: " + answer.getClass().getName() + " expected type was: " + type,
+                    t
+                );
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public <T> Map<String, T> findByTypeWithName(Class<T> type) {
+        final Map<String, T> result = new HashMap<>();
+
+        registry.entrySet().stream()
+            .filter(entry -> type.isInstance(entry.getValue()))
+            .forEach(entry -> result.put(entry.getKey(), type.cast(entry.getValue())));
+
+        return result;
+    }
+
+    @Override
+    public <T> Set<T> findByType(Class<T> type) {
+        return registry.values().stream()
+            .filter(type::isInstance)
+            .map(type::cast)
+            .collect(Collectors.toSet());
+    }
+}

--- a/camel-k-adapter-camel-2/src/main/java/org/apache/camel/k/adapter/Main.java
+++ b/camel-k-adapter-camel-2/src/main/java/org/apache/camel/k/adapter/Main.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.k.adapter;
+
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ProducerTemplate;
+
+public class Main extends org.apache.camel.main.MainSupport {
+    private CamelContext context;
+
+    public Main(CamelContext context) {
+        this.context = context;
+    }
+
+    @Override
+    protected ProducerTemplate findOrCreateCamelTemplate() {
+        return context.createProducerTemplate();
+    }
+
+    @Override
+    protected Map<String, CamelContext> getCamelContextMap() {
+        return Collections.singletonMap(context.getName(), context);
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+        postProcessContext();
+
+        try {
+            context.start();
+        } finally {
+            if (context.isVetoStarted()) {
+                completed();
+            }
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+
+        if (!getCamelContexts().isEmpty()) {
+            context.stop();
+        }
+    }
+}

--- a/camel-k-adapter-camel-2/src/main/java/org/apache/camel/k/adapter/Registry.java
+++ b/camel-k-adapter-camel-2/src/main/java/org/apache/camel/k/adapter/Registry.java
@@ -14,19 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.k.adapter;
 
-package org.apache.camel.k.tooling.maven.processors;
+import java.util.Map;
 
-import org.apache.camel.catalog.CamelCatalog;
-import org.apache.camel.catalog.DefaultCamelCatalog;
+public interface Registry extends org.apache.camel.spi.Registry {
+    void bind(String name, Object bean);
 
-public abstract class AbstractCataloProcessorTest {
-    protected CamelCatalog versionCamelCatalog(String version){
-        return new DefaultCamelCatalog() {
-            @Override
-            public String getCatalogVersion() {
-                return version;
-            }
-        };
+    @SuppressWarnings("deprecation")
+    default public Object lookup(String name) {
+        return lookupByName(name);
+    }
+
+    @SuppressWarnings("deprecation")
+    default public <T> T lookup(String name, Class<T> type) {
+        return lookupByNameAndType(name, type);
+    }
+
+    @SuppressWarnings("deprecation")
+    default public <T> Map<String, T> lookupByType(Class<T> type) {
+        return findByTypeWithName(type);
     }
 }

--- a/camel-k-adapter-camel-2/src/main/java/org/apache/camel/k/adapter/Resources.java
+++ b/camel-k-adapter-camel-2/src/main/java/org/apache/camel/k/adapter/Resources.java
@@ -20,6 +20,9 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.model.ModelHelper;
+import org.apache.camel.model.RoutesDefinition;
+import org.apache.camel.model.rest.RestsDefinition;
 import org.apache.camel.util.ResourceHelper;
 
 public final class Resources {
@@ -28,5 +31,13 @@ public final class Resources {
 
     public static InputStream resolveResourceAsInputStream(CamelContext camelContext, String uri) throws IOException {
         return ResourceHelper.resolveMandatoryResourceAsInputStream(camelContext, uri);
+    }
+
+    public static RoutesDefinition loadRoutesDefinition(CamelContext camelContext, InputStream is) throws Exception {
+        return camelContext.loadRoutesDefinition(is);
+    }
+
+    public static RestsDefinition loadRestsDefinition(CamelContext camelContext, InputStream is) throws Exception {
+        return camelContext.loadRestsDefinition(is);
     }
 }

--- a/camel-k-adapter-camel-2/src/main/java/org/apache/camel/k/adapter/Routes.java
+++ b/camel-k-adapter-camel-2/src/main/java/org/apache/camel/k/adapter/Routes.java
@@ -14,19 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.k.adapter;
 
-package org.apache.camel.k.tooling.maven.processors;
+import org.apache.camel.model.FromDefinition;
+import org.apache.camel.model.RouteDefinition;
 
-import org.apache.camel.catalog.CamelCatalog;
-import org.apache.camel.catalog.DefaultCamelCatalog;
-
-public abstract class AbstractCataloProcessorTest {
-    protected CamelCatalog versionCamelCatalog(String version){
-        return new DefaultCamelCatalog() {
-            @Override
-            public String getCatalogVersion() {
-                return version;
-            }
-        };
+public final class Routes {
+    public static FromDefinition getInput(RouteDefinition definition) {
+        return definition.getInputs().get(0);
     }
 }

--- a/camel-k-adapter-camel-3/src/main/java/org/apache/camel/k/adapter/DefaultRegistry.java
+++ b/camel-k-adapter-camel-3/src/main/java/org/apache/camel/k/adapter/DefaultRegistry.java
@@ -14,19 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.k.adapter;
 
-package org.apache.camel.k.tooling.maven.processors;
-
-import org.apache.camel.catalog.CamelCatalog;
-import org.apache.camel.catalog.DefaultCamelCatalog;
-
-public abstract class AbstractCataloProcessorTest {
-    protected CamelCatalog versionCamelCatalog(String version){
-        return new DefaultCamelCatalog() {
-            @Override
-            public String getCatalogVersion() {
-                return version;
-            }
-        };
-    }
+public class DefaultRegistry extends org.apache.camel.support.DefaultRegistry implements Registry {
 }

--- a/camel-k-adapter-camel-3/src/main/java/org/apache/camel/k/adapter/Main.java
+++ b/camel-k-adapter-camel-3/src/main/java/org/apache/camel/k/adapter/Main.java
@@ -16,28 +16,42 @@
  */
 package org.apache.camel.k.adapter;
 
-import java.io.IOException;
-import java.io.InputStream;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.model.ModelHelper;
-import org.apache.camel.model.RoutesDefinition;
-import org.apache.camel.model.rest.RestsDefinition;
-import org.apache.camel.support.ResourceHelper;
+import org.apache.camel.ProducerTemplate;
 
-public final class Resources {
-    private Resources() {
+public class Main extends org.apache.camel.main.MainSupport {
+    public Main(CamelContext context) {
+        this.camelContext = context;
     }
 
-    public static InputStream resolveResourceAsInputStream(CamelContext camelContext, String uri) throws IOException {
-        return ResourceHelper.resolveMandatoryResourceAsInputStream(camelContext, uri);
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+        postProcessCamelContext(camelContext);
+
+        try {
+            // if we were veto started then mark as completed
+            this.camelContext.start();
+        } finally {
+            if (this.camelContext.isVetoStarted()) {
+                completed();
+            }
+        }
     }
 
-    public static RoutesDefinition loadRoutesDefinition(CamelContext camelContext, InputStream is) throws Exception {
-        return ModelHelper.loadRoutesDefinition(camelContext, is);
+    protected void doStop() throws Exception {
+        super.doStop();
+        this.camelContext.stop();
     }
 
-    public static RestsDefinition loadRestsDefinition(CamelContext camelContext, InputStream is) throws Exception {
-        return ModelHelper.loadRestsDefinition(camelContext, is);
+    @Override
+    protected ProducerTemplate findOrCreateCamelTemplate() {
+        return this.camelContext.createProducerTemplate();
+    }
+
+    @Override
+    protected CamelContext createCamelContext() {
+        return this.camelContext;
     }
 }

--- a/camel-k-adapter-camel-3/src/main/java/org/apache/camel/k/adapter/Registry.java
+++ b/camel-k-adapter-camel-3/src/main/java/org/apache/camel/k/adapter/Registry.java
@@ -14,19 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.k.adapter;
 
-package org.apache.camel.k.tooling.maven.processors;
-
-import org.apache.camel.catalog.CamelCatalog;
-import org.apache.camel.catalog.DefaultCamelCatalog;
-
-public abstract class AbstractCataloProcessorTest {
-    protected CamelCatalog versionCamelCatalog(String version){
-        return new DefaultCamelCatalog() {
-            @Override
-            public String getCatalogVersion() {
-                return version;
-            }
-        };
-    }
+public interface Registry extends org.apache.camel.spi.Registry {
 }

--- a/camel-k-adapter-camel-3/src/main/java/org/apache/camel/k/adapter/Routes.java
+++ b/camel-k-adapter-camel-3/src/main/java/org/apache/camel/k/adapter/Routes.java
@@ -14,19 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.k.adapter;
 
-package org.apache.camel.k.tooling.maven.processors;
+import org.apache.camel.model.FromDefinition;
+import org.apache.camel.model.RouteDefinition;
 
-import org.apache.camel.catalog.CamelCatalog;
-import org.apache.camel.catalog.DefaultCamelCatalog;
-
-public abstract class AbstractCataloProcessorTest {
-    protected CamelCatalog versionCamelCatalog(String version){
-        return new DefaultCamelCatalog() {
-            @Override
-            public String getCatalogVersion() {
-                return version;
-            }
-        };
+public final class Routes {
+    public static FromDefinition getInput(RouteDefinition definition) {
+        return definition.getInput();
     }
 }

--- a/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateRestXML.java
+++ b/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateRestXML.java
@@ -1,4 +1,3 @@
-package org.apache.camel.k.tooling.maven;
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,6 +14,7 @@ package org.apache.camel.k.tooling.maven;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.k.tooling.maven;
 
 import java.io.PrintWriter;
 import java.io.Writer;

--- a/camel-k-maven-plugin/src/test/java/org/apache/camel/k/tooling/maven/processors/CataloProcessor2Test.java
+++ b/camel-k-maven-plugin/src/test/java/org/apache/camel/k/tooling/maven/processors/CataloProcessor2Test.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.camel.k.tooling.maven.processors;
 
 import org.apache.camel.catalog.CamelCatalog;

--- a/camel-k-maven-plugin/src/test/java/org/apache/camel/k/tooling/maven/processors/CataloProcessor3Test.java
+++ b/camel-k-maven-plugin/src/test/java/org/apache/camel/k/tooling/maven/processors/CataloProcessor3Test.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.camel.k.tooling.maven.processors;
 
 import org.apache.camel.catalog.CamelCatalog;

--- a/camel-k-runtime-core/src/main/java/org/apache/camel/k/InMemoryRegistry.java
+++ b/camel-k-runtime-core/src/main/java/org/apache/camel/k/InMemoryRegistry.java
@@ -16,66 +16,7 @@
  */
 package org.apache.camel.k;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
+import org.apache.camel.k.adapter.DefaultRegistry;
 
-import org.apache.camel.NoSuchBeanException;
-
-public final class InMemoryRegistry implements Runtime.Registry {
-    private final ConcurrentMap<String, Object> registry;
-
-    public InMemoryRegistry() {
-        this.registry = new ConcurrentHashMap<>();
-    }
-
-    public void bind(String name, Object bean) {
-        this.registry.put(name, bean);
-    }
-
-    @Override
-    public Object lookupByName(String name) {
-        return registry.get(name);
-    }
-
-    @Override
-    public <T> T lookupByNameAndType(String name, Class<T> type) {
-        final Object answer = lookupByName(name);
-
-        if (answer != null) {
-            try {
-                return type.cast(answer);
-            } catch (Throwable t) {
-                throw new NoSuchBeanException(
-                    name,
-                    "Found bean: " + name + " in RuntimeRegistry: " + this + " of type: " + answer.getClass().getName() + " expected type was: " + type,
-                    t
-                );
-            }
-        }
-
-        return null;
-    }
-
-    @Override
-    public <T> Map<String, T> findByTypeWithName(Class<T> type) {
-        final Map<String, T> result = new HashMap<>();
-
-        registry.entrySet().stream()
-            .filter(entry -> type.isInstance(entry.getValue()))
-            .forEach(entry -> result.put(entry.getKey(), type.cast(entry.getValue())));
-
-        return result;
-    }
-
-    @Override
-    public <T> Set<T> findByType(Class<T> type) {
-        return registry.values().stream()
-            .filter(type::isInstance)
-            .map(type::cast)
-            .collect(Collectors.toSet());
-    }
+public class InMemoryRegistry extends DefaultRegistry implements Runtime.Registry {
 }

--- a/camel-k-runtime-core/src/main/java/org/apache/camel/k/Runtime.java
+++ b/camel-k-runtime-core/src/main/java/org/apache/camel/k/Runtime.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.k;
 
-import java.util.Map;
 import java.util.Properties;
 
 import org.apache.camel.CamelContext;
@@ -54,22 +53,6 @@ public interface Runtime {
         void accept(Phase phase, Runtime runtime);
     }
 
-    interface Registry extends org.apache.camel.spi.Registry {
-        void bind(String name, Object bean);
-
-        @SuppressWarnings("deprecation")
-        default public Object lookup(String name) {
-            return lookupByName(name);
-        }
-
-        @SuppressWarnings("deprecation")
-        default public <T> T lookup(String name, Class<T> type) {
-            return lookupByNameAndType(name, type);
-        }
-
-        @SuppressWarnings("deprecation")
-        default public <T> Map<String, T> lookupByType(Class<T> type) {
-            return findByTypeWithName(type);
-        }
+    interface Registry extends org.apache.camel.k.adapter.Registry {
     }
 }

--- a/camel-k-runtime-groovy/src/test/groovy/org/apache/camel/k/groovy/LoaderTest.groovy
+++ b/camel-k-runtime-groovy/src/test/groovy/org/apache/camel/k/groovy/LoaderTest.groovy
@@ -19,6 +19,7 @@ package org.apache.camel.k.groovy
 import org.apache.camel.impl.DefaultCamelContext
 import org.apache.camel.k.InMemoryRegistry
 import org.apache.camel.k.Source
+import org.apache.camel.k.adapter.Routes
 import org.apache.camel.k.support.RuntimeSupport
 import org.apache.camel.model.ToDefinition
 import spock.lang.Specification
@@ -44,7 +45,8 @@ class LoaderTest extends Specification {
             def routes = builder.routeCollection.routes
 
             routes.size() == 1
-            routes[0].inputs[0].endpointUri == 'timer:tick'
             routes[0].outputs[0] instanceof ToDefinition
+
+            Routes.getInput(routes[0]).endpointUri == 'timer:tick'
     }
 }

--- a/camel-k-runtime-jvm/src/main/java/org/apache/camel/k/jvm/loader/XmlLoader.java
+++ b/camel-k-runtime-jvm/src/main/java/org/apache/camel/k/jvm/loader/XmlLoader.java
@@ -25,6 +25,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.k.RoutesLoader;
 import org.apache.camel.k.Runtime;
 import org.apache.camel.k.Source;
+import org.apache.camel.k.adapter.Resources;
 import org.apache.camel.k.support.URIResolver;
 import org.apache.camel.model.RoutesDefinition;
 import org.apache.camel.model.rest.RestsDefinition;
@@ -46,7 +47,7 @@ public class XmlLoader implements RoutesLoader {
             public void configure() throws Exception {
                 try (InputStream is = URIResolver.resolve(getContext(), source)) {
                     try {
-                        RoutesDefinition definition = getContext().loadRoutesDefinition(is);
+                        RoutesDefinition definition = Resources.loadRoutesDefinition(getContext(), is);
                         LOGGER.debug("Loaded {} routes from {}", definition.getRoutes().size(), source);
 
                         setRouteCollection(definition);
@@ -59,7 +60,7 @@ public class XmlLoader implements RoutesLoader {
 
                 try (InputStream is = URIResolver.resolve(getContext(), source)) {
                     try {
-                        RestsDefinition definition = getContext().loadRestsDefinition(is);
+                        RestsDefinition definition = Resources.loadRestsDefinition(getContext(), is);
                         LOGGER.debug("Loaded {} rests from {}", definition.getRests().size(), source);
 
                         setRestCollection(definition);

--- a/camel-k-runtime-jvm/src/test/java/org/apache/camel/k/jvm/RoutesLoadersCommonTest.java
+++ b/camel-k-runtime-jvm/src/test/java/org/apache/camel/k/jvm/RoutesLoadersCommonTest.java
@@ -24,6 +24,7 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.k.InMemoryRegistry;
 import org.apache.camel.k.RoutesLoader;
 import org.apache.camel.k.Source;
+import org.apache.camel.k.adapter.Routes;
 import org.apache.camel.k.jvm.loader.JavaClassLoader;
 import org.apache.camel.k.jvm.loader.JavaScriptLoader;
 import org.apache.camel.k.jvm.loader.JavaSourceLoader;
@@ -53,7 +54,7 @@ public class RoutesLoadersCommonTest {
 
         List<RouteDefinition> routes = builder.getRouteCollection().getRoutes();
         assertThat(routes).hasSize(1);
-        assertThat(routes.get(0).getInputs().get(0).getEndpointUri()).isEqualTo("timer:tick");
+        assertThat(Routes.getInput(routes.get(0)).getEndpointUri()).isEqualTo("timer:tick");
         assertThat(routes.get(0).getOutputs().get(0)).isInstanceOf(ToDefinition.class);
     }
 

--- a/camel-k-runtime-jvm/src/test/java/org/apache/camel/k/jvm/RoutesLoadersTest.java
+++ b/camel-k-runtime-jvm/src/test/java/org/apache/camel/k/jvm/RoutesLoadersTest.java
@@ -25,6 +25,7 @@ import org.apache.camel.k.InMemoryRegistry;
 import org.apache.camel.k.RoutesLoader;
 import org.apache.camel.k.Runtime;
 import org.apache.camel.k.Source;
+import org.apache.camel.k.adapter.Routes;
 import org.apache.camel.k.jvm.loader.JavaClassLoader;
 import org.apache.camel.k.jvm.loader.JavaSourceLoader;
 import org.apache.camel.k.support.RuntimeSupport;
@@ -68,7 +69,7 @@ public class RoutesLoadersTest {
 
         List<RouteDefinition> routes = builder.getRouteCollection().getRoutes();
         assertThat(routes).hasSize(1);
-        assertThat(routes.get(0).getInputs().get(0).getEndpointUri()).isEqualTo("timer:tick");
+        assertThat(Routes.getInput(routes.get(0)).getEndpointUri()).isEqualTo("timer:tick");
         assertThat(routes.get(0).getOutputs().get(0)).isInstanceOf(SetBodyDefinition.class);
         assertThat(routes.get(0).getOutputs().get(1)).isInstanceOf(ProcessDefinition.class);
         assertThat(routes.get(0).getOutputs().get(2)).isInstanceOf(ToDefinition.class);

--- a/camel-k-runtime-kotlin/src/test/kotlin/org/apache/camel/k/kotlin/LoaderTest.kt
+++ b/camel-k-runtime-kotlin/src/test/kotlin/org/apache/camel/k/kotlin/LoaderTest.kt
@@ -19,6 +19,7 @@ package org.apache.camel.k.kotlin
 import org.apache.camel.impl.DefaultCamelContext
 import org.apache.camel.k.InMemoryRegistry
 import org.apache.camel.k.Source
+import org.apache.camel.k.adapter.Routes
 import org.apache.camel.k.support.RuntimeSupport
 import org.apache.camel.model.ProcessDefinition
 import org.apache.camel.model.ToDefinition
@@ -42,7 +43,7 @@ class LoaderTest {
 
         val routes = builder.routeCollection.routes
         assertThat(routes).hasSize(1)
-        assertThat(routes[0].inputs[0].endpointUri).isEqualTo("timer:tick")
+        assertThat(Routes.getInput(routes[0]).endpointUri).isEqualTo("timer:tick")
         assertThat(routes[0].outputs[0]).isInstanceOf(ProcessDefinition::class.java)
         assertThat(routes[0].outputs[1]).isInstanceOf(ToDefinition::class.java)
     }

--- a/camel-k-runtime-spring-boot/src/main/java/org/apache/camel/k/spring/boot/ApplicationAutoConfiguration.java
+++ b/camel-k-runtime-spring-boot/src/main/java/org/apache/camel/k/spring/boot/ApplicationAutoConfiguration.java
@@ -19,20 +19,18 @@ package org.apache.camel.k.spring.boot;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.k.InMemoryRegistry;
 import org.apache.camel.k.Runtime;
 import org.apache.camel.k.listener.ContextConfigurer;
 import org.apache.camel.k.listener.RoutesConfigurer;
 import org.apache.camel.k.listener.RoutesDumper;
-import org.apache.camel.k.support.RuntimeSupport;
 import org.apache.camel.spring.boot.CamelContextConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 
 @Configuration
 public class ApplicationAutoConfiguration {
@@ -95,7 +93,7 @@ public class ApplicationAutoConfiguration {
         }
     }
 
-    private static class RuntimeApplicationContextRegistry implements Runtime.Registry {
+    private static class RuntimeApplicationContextRegistry extends InMemoryRegistry {
         private final ConfigurableApplicationContext applicationContext;
         private final org.apache.camel.spi.Registry registry;
 
@@ -123,10 +121,5 @@ public class ApplicationAutoConfiguration {
         public <T> Set<T> findByType(Class<T> type) {
             return registry.findByType(type);
         }
-        @Override
-        public void bind(String name, Object bean) {
-            applicationContext.getBeanFactory().registerSingleton(name, bean);
-        }
     }
-
 }

--- a/camel-k-runtime-yaml/src/test/java/org/apache/camel/k/yaml/RoutesLoaderTest.java
+++ b/camel-k-runtime-yaml/src/test/java/org/apache/camel/k/yaml/RoutesLoaderTest.java
@@ -21,9 +21,10 @@ import java.util.List;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.k.InMemoryRegistry;
 import org.apache.camel.k.RoutesLoader;
 import org.apache.camel.k.Source;
-import org.apache.camel.k.InMemoryRegistry;
+import org.apache.camel.k.adapter.Routes;
 import org.apache.camel.k.support.RuntimeSupport;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.ToDefinition;
@@ -48,7 +49,7 @@ public class RoutesLoaderTest {
 
         List<RouteDefinition> routes = builder.getRouteCollection().getRoutes();
         assertThat(routes).hasSize(1);
-        assertThat(routes.get(0).getInputs().get(0).getEndpointUri()).isEqualTo("timer:tick");
+        assertThat(Routes.getInput(routes.get(0)).getEndpointUri()).isEqualTo("timer:tick");
         assertThat(routes.get(0).getOutputs().get(0)).isInstanceOf(ToDefinition.class);
     }
 }

--- a/camel-knative-http/src/main/java/org/apache/camel/component/knative/http/KnativeHttpComponent.java
+++ b/camel-knative-http/src/main/java/org/apache/camel/component/knative/http/KnativeHttpComponent.java
@@ -54,7 +54,6 @@ import org.apache.camel.component.netty4.http.NettyHttpConfiguration;
 import org.apache.camel.component.netty4.http.NettyHttpConsumer;
 import org.apache.camel.component.netty4.http.NettyHttpHelper;
 import org.apache.camel.component.netty4.http.handlers.HttpServerChannelHandler;
-import org.apache.camel.http.common.CamelServlet;
 import org.apache.camel.k.adapter.Exceptions;
 import org.apache.camel.k.adapter.Objects;
 import org.apache.camel.k.adapter.Services;
@@ -66,7 +65,6 @@ import org.apache.camel.util.UnsafeUriCharactersEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -156,17 +154,7 @@ public class KnativeHttpComponent extends NettyHttpComponent {
                 }
                 handler.channelRead(ctx, request);
             } else {
-                // okay we cannot process this requires so return either 404 or 405.
-                // to know if its 405 then we need to check if any other HTTP method would have a consumer for the "same" request
-                boolean hasAnyMethod = CamelServlet.METHODS.stream().anyMatch(m -> isHttpMethodAllowed(request, m));
-                HttpResponse response = null;
-                if (hasAnyMethod) {
-                    //method match error, return 405
-                    response = new DefaultHttpResponse(HTTP_1_1, METHOD_NOT_ALLOWED);
-                } else {
-                    // this resource is not found, return 404
-                    response = new DefaultHttpResponse(HTTP_1_1, NOT_FOUND);
-                }
+                HttpResponse response = new DefaultHttpResponse(HTTP_1_1, NOT_FOUND);
                 response.headers().set(Exchange.CONTENT_TYPE, "text/plain");
                 response.headers().set(Exchange.CONTENT_LENGTH, 0);
                 ctx.writeAndFlush(response);

--- a/camel-knative-http/src/test/java/org/apache/camel/component/knative/http/KnativeHttpMain.java
+++ b/camel-knative-http/src/test/java/org/apache/camel/component/knative/http/KnativeHttpMain.java
@@ -18,12 +18,10 @@ package org.apache.camel.component.knative.http;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.camel.impl.SimpleRegistry;
 
 public class KnativeHttpMain {
     public static void main(String[] args) throws Exception {
-        SimpleRegistry registry = new SimpleRegistry();
-        DefaultCamelContext context = new DefaultCamelContext(registry);
+        DefaultCamelContext context = new DefaultCamelContext();
 
         try {
             context.disableJMX();

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <camel2.version>2.23.1</camel2.version>
-        <camel3.version>3.0.0-M1</camel3.version>
+        <camel3.version>3.0.0-M2</camel3.version>
         <camel.version>${camel2.version}</camel.version>
         <catalog.version>${camel.version}</catalog.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
this supersede #39

I think we should discuss the option to drop support to camel 2.x when 3.x will hit its first release but till that date we should make some effort to support both.

@davsclaus @nicolaferraro @oscerd @astefanutti, what do you think ?
