### PR TITLE
Rollback to 0.3.2-SNAPSHOT and re-enable missing module

### DIFF
--- a/camel-k-adapter-camel-2/pom.xml
+++ b/camel-k-adapter-camel-2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-adapter-camel-3/pom.xml
+++ b/camel-k-adapter-camel-3/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-maven-plugin/pom.xml
+++ b/camel-k-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.camel.k</groupId>
     <artifactId>camel-k-runtime-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.2-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/camel-k-runtime-bom/pom.xml
+++ b/camel-k-runtime-bom/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.k</groupId>
     <artifactId>camel-k-runtime-bom</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/camel-k-runtime-core/pom.xml
+++ b/camel-k-runtime-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-runtime-groovy/pom.xml
+++ b/camel-k-runtime-groovy/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-runtime-health/pom.xml
+++ b/camel-k-runtime-health/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-runtime-jvm/pom.xml
+++ b/camel-k-runtime-jvm/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-runtime-kotlin/pom.xml
+++ b/camel-k-runtime-kotlin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-runtime-spring-boot-layout/pom.xml
+++ b/camel-k-runtime-spring-boot-layout/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/camel-k-runtime-spring-boot/pom.xml
+++ b/camel-k-runtime-spring-boot/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/camel-k-runtime-yaml/pom.xml
+++ b/camel-k-runtime-yaml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-knative-http/pom.xml
+++ b/camel-knative-http/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-knative/pom.xml
+++ b/camel-knative/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>camel-k-runtime-parent</artifactId>
     <groupId>org.apache.camel.k</groupId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.k</groupId>
     <artifactId>camel-k-runtime-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
 
     <modules>
         <module>camel-k-adapter-camel-2</module>
+        <module>camel-k-adapter-camel-3</module>
         <module>camel-k-maven-plugin</module>
         <module>camel-k-runtime-core</module>
         <module>camel-k-runtime-jvm</module>
@@ -255,9 +256,6 @@
                     <name>camel3</name>
                 </property>
             </activation>
-            <modules>
-                <module>camel-k-adapter-camel-3</module>
-            </modules>
             <dependencyManagement>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
Preparing to cut a new 0.3.2 release.