### PR TITLE
Fix the camel-k-runtime-example running issue

### DIFF
--- a/camel-k-runtime-examples/camel-k-runtime-example-health/pom.xml
+++ b/camel-k-runtime-examples/camel-k-runtime-example-health/pom.xml
@@ -89,7 +89,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>org.apache.camel.k.jvm.Application</mainClass>
+                    <mainClass>org.apache.camel.k.main.Application</mainClass>
                     <classpathScope>runtime</classpathScope>
                     <systemProperties>
                         <systemProperty>

--- a/camel-k-runtime-examples/camel-k-runtime-example-servlet/pom.xml
+++ b/camel-k-runtime-examples/camel-k-runtime-example-servlet/pom.xml
@@ -85,7 +85,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>org.apache.camel.k.jvm.Application</mainClass>
+                    <mainClass>org.apache.camel.k.main.Application</mainClass>
                     <classpathScope>runtime</classpathScope>
                     <systemProperties>
                         <systemProperty>

--- a/camel-k-runtime-examples/camel-k-runtime-example-yaml/pom.xml
+++ b/camel-k-runtime-examples/camel-k-runtime-example-yaml/pom.xml
@@ -88,7 +88,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>org.apache.camel.k.jvm.Application</mainClass>
+                    <mainClass>org.apache.camel.k.main.Application</mainClass>
                     <classpathScope>runtime</classpathScope>
                     <systemProperties>
                         <systemProperty>


### PR DESCRIPTION
After the recent refactor of camel-k-runtime,  the main class name of camel-k-runtime-main was changed which breaked the running of camel-k-runtime-examples with 'mvn exec:java'. 