### PR TITLE
Knative component filters out all headers

### DIFF
--- a/camel-knative-http/pom.xml
+++ b/camel-knative-http/pom.xml
@@ -58,6 +58,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${commons-collections4.version}</version>
+        </dependency>
+
         <!-- ****************************** -->
         <!--                                -->
         <!-- TESTS                          -->

--- a/camel-knative/pom.xml
+++ b/camel-knative/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>camel-netty4-http</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-undertow</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/camel-knative/src/main/java/org/apache/camel/component/knative/KnativeComponent.java
+++ b/camel-knative/src/main/java/org/apache/camel/component/knative/KnativeComponent.java
@@ -16,11 +16,13 @@
  */
 package org.apache.camel.component.knative;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.support.DefaultComponent;
+import org.apache.camel.support.IntrospectionSupport;
 import org.apache.camel.support.PropertyBindingSupport;
 import org.apache.camel.util.StringHelper;
 
@@ -88,6 +90,17 @@ public class KnativeComponent extends DefaultComponent {
         configuration.setCloudEventsSpecVersion(cloudEventSpecVersion);
     }
 
+    public Map<String, Object> getTransportOptions() {
+        return configuration.getTransportOptions();
+    }
+
+    /**
+     * Transport options.
+     */
+    public void setTransportOptions(Map<String, Object> transportOptions) {
+        configuration.setTransportOptions(transportOptions);
+    }
+
     // ************************
     //
     //
@@ -100,8 +113,13 @@ public class KnativeComponent extends DefaultComponent {
         final String target = StringHelper.after(remaining, "/");
         final KnativeConfiguration conf = getKnativeConfiguration();
 
+        conf.getTransportOptions().putAll(
+            IntrospectionSupport.extractProperties(parameters, "transport.", true)
+        );
+
         // set properties from the endpoint uri
         PropertyBindingSupport.bindProperties(getCamelContext(), conf, parameters);
+
 
         return new KnativeEndpoint(uri, this, Knative.Type.valueOf(type), target, conf);
     }
@@ -114,6 +132,10 @@ public class KnativeComponent extends DefaultComponent {
 
     private KnativeConfiguration getKnativeConfiguration() throws Exception {
         KnativeConfiguration conf = configuration.copy();
+
+        if (conf.getTransportOptions() == null) {
+            conf.setTransportOptions(new HashMap<>());
+        }
 
         if (conf.getEnvironment() == null) {
             String envConfig = System.getenv(CONFIGURATION_ENV_VARIABLE);

--- a/camel-knative/src/main/java/org/apache/camel/component/knative/KnativeConfiguration.java
+++ b/camel-knative/src/main/java/org/apache/camel/component/knative/KnativeConfiguration.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.knative;
 
+import java.util.Map;
+
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spi.UriParam;
 
@@ -31,6 +33,9 @@ public class KnativeConfiguration implements Cloneable {
 
     @UriParam(defaultValue = "org.apache.camel.event")
     private String cloudEventsType = "org.apache.camel.event";
+
+    @UriParam(prefix = "transport.")
+    private Map<String, Object> transportOptions;
 
     public KnativeConfiguration() {
     }
@@ -84,6 +89,17 @@ public class KnativeConfiguration implements Cloneable {
      */
     public void setCloudEventsType(String cloudEventsType) {
         this.cloudEventsType = cloudEventsType;
+    }
+
+    public Map<String, Object> getTransportOptions() {
+        return transportOptions;
+    }
+
+    /**
+     * Set the transport options.
+     */
+    public void setTransportOptions(Map<String, Object> transportOptions) {
+        this.transportOptions = transportOptions;
     }
 
     // ************************

--- a/camel-knative/src/main/java/org/apache/camel/component/knative/KnativeEndpoint.java
+++ b/camel-knative/src/main/java/org/apache/camel/component/knative/KnativeEndpoint.java
@@ -71,7 +71,7 @@ public class KnativeEndpoint extends DefaultEndpoint implements DelegateEndpoint
         switch (service.getProtocol()) {
         case http:
         case https:
-            this.endpoint = http(component.getCamelContext(), service);
+            this.endpoint = http(component.getCamelContext(), service, configuration.getTransportOptions());
             break;
         default:
             throw new IllegalArgumentException("unsupported protocol: " + this.service.getProtocol());
@@ -148,7 +148,7 @@ public class KnativeEndpoint extends DefaultEndpoint implements DelegateEndpoint
     //
     // *****************************
 
-    private static Endpoint http(CamelContext context, ServiceDefinition definition) {
+    private static Endpoint http(CamelContext context, ServiceDefinition definition, Map<String, Object> transportOptions) {
         try {
             final String scheme = Knative.HTTP_COMPONENT;
             final String protocol = definition.getMetadata().getOrDefault(Knative.KNATIVE_PROTOCOL, "http");
@@ -195,6 +195,8 @@ public class KnativeEndpoint extends DefaultEndpoint implements DelegateEndpoint
             final String filterVal = definition.getMetadata().get(Knative.FILTER_HEADER_VALUE);
             final Map<String, Object> parameters = new HashMap<>();
 
+            parameters.putAll(transportOptions);
+
             if (ObjectHelper.isNotEmpty(filterKey) && ObjectHelper.isNotEmpty(filterVal)) {
                 parameters.put("filter.headerName", filterKey);
                 parameters.put("filter.headerValue", filterVal);
@@ -202,7 +204,7 @@ public class KnativeEndpoint extends DefaultEndpoint implements DelegateEndpoint
 
             // configure netty to use relative path instead of full
             // path that is the default to make istio working
-            parameters.put("useRelativePath", "true");
+            //parameters.put("useRelativePath", "true");
 
             uri = URISupport.appendParametersToURI(uri, parameters);
 


### PR DESCRIPTION
You cna configure the transport by using properties with 'transport.' as 
prefix, as example, to configure a custom header filter strategy, one 
can define the endpoint like:

    knative:endpoint/myEndpoint?transport.headerFilterStrategy=#myFilterStrategy

Fixes #118