### PR TITLE
Classname does not match the Filename.

### DIFF
--- a/docs/modules/languages/pages/java.adoc
+++ b/docs/modules/languages/pages/java.adoc
@@ -7,7 +7,7 @@ Using Java to write an integration to be deployed using Camel K is no different 
 ----
 import org.apache.camel.builder.RouteBuilder;
 
-public class Sample extends RouteBuilder {
+public class Example extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         from("timer:tick")


### PR DESCRIPTION
If you try to run this example you will get a compilation error "class Sample is public, should be declared in a file named Sample.java". To solve this and to be consistent to the other language examples, the class should be renamed to Example.