### PR TITLE
yaml-loader: add support for error handler

### DIFF
--- a/camel-k-loader-yaml/camel-k-loader-yaml-common/src/main/java/org/apache/camel/k/loader/yaml/parser/ErrorHandlerStepParser.java
+++ b/camel-k-loader-yaml/camel-k-loader-yaml-common/src/main/java/org/apache/camel/k/loader/yaml/parser/ErrorHandlerStepParser.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.k.loader.yaml.parser;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import org.apache.camel.builder.DeadLetterChannelBuilder;
+import org.apache.camel.builder.DefaultErrorHandlerBuilder;
+import org.apache.camel.builder.ErrorHandlerBuilder;
+import org.apache.camel.builder.ErrorHandlerBuilderRef;
+import org.apache.camel.builder.NoErrorHandlerBuilder;
+import org.apache.camel.k.annotation.yaml.YAMLStepParser;
+import org.apache.camel.k.loader.yaml.spi.ProcessorStepParser;
+import org.apache.camel.k.loader.yaml.spi.StartStepParser;
+import org.apache.camel.k.loader.yaml.spi.StepParserSupport;
+import org.apache.camel.model.ProcessorDefinition;
+import org.apache.camel.model.RouteDefinition;
+
+@YAMLStepParser("error-handler")
+public class ErrorHandlerStepParser implements StartStepParser, ProcessorStepParser {
+    @Override
+    public ProcessorDefinition<?> toStartProcessor(Context context) {
+        final Definition definition = context.node(Definition.class);
+
+        StepParserSupport.notNull(definition.builder, "builder");
+
+        context.builder().errorHandler(definition.builder);
+
+        return context.processor();
+    }
+
+    @Override
+    public ProcessorDefinition<?> toProcessor(Context context) {
+        final Definition definition = context.node(Definition.class);
+
+        StepParserSupport.notNull(context.processor(), "processor");
+        StepParserSupport.notNull(definition.builder, "builder");
+
+        return context.processor(RouteDefinition.class).errorHandler(definition.builder);
+    }
+
+    public static final class Definition {
+        public ErrorHandlerBuilder builder;
+
+        @JsonAlias("default")
+        public void setDefault(DefaultErrorHandlerBuilder builder) {
+            setBuilder(builder);
+        }
+
+        @JsonAlias("dead-letter-channel")
+        public void setDeadLetterChannel(DeadLetterChannelBuilder builder) {
+            setBuilder(builder);
+        }
+
+        @JsonAlias({"no-error-handler", "none" })
+        public void setNoErrorHandler(NoErrorHandlerBuilder builder) {
+            setBuilder(builder);
+        }
+
+        @JsonAlias("ref")
+        public void setRefHandler(ErrorHandlerBuilderRef builder) {
+            setBuilder(builder);
+        }
+
+        private void setBuilder(ErrorHandlerBuilder builder) {
+            if (this.builder != null) {
+                throw new IllegalArgumentException("An ErrorHandler has already been set");
+            }
+
+            this.builder = builder;
+        }
+    }
+}
+

--- a/camel-k-loader-yaml/camel-k-loader-yaml-common/src/main/java/org/apache/camel/k/loader/yaml/spi/StepParserSupport.java
+++ b/camel-k-loader-yaml/camel-k-loader-yaml-common/src/main/java/org/apache/camel/k/loader/yaml/spi/StepParserSupport.java
@@ -46,9 +46,8 @@ public final class StepParserSupport {
         ProcessorDefinition<?> current = parent;
 
         for (Step step : steps) {
-
             ProcessorDefinition<?> child = ProcessorStepParser.invoke(
-                ProcessorStepParser.Context.of(context, step.node),
+                ProcessorStepParser.Context.of(context, current, step.node),
                 step.id
             );
 

--- a/camel-k-loader-yaml/camel-k-loader-yaml/src/main/java/org/apache/camel/k/loader/yaml/YamlSourceLoader.java
+++ b/camel-k-loader-yaml/camel-k-loader-yaml/src/main/java/org/apache/camel/k/loader/yaml/YamlSourceLoader.java
@@ -91,7 +91,7 @@ public class YamlSourceLoader implements SourceLoader {
                 try (is) {
                     for (Step step : mapper.readValue(is, Step[].class)) {
                         StartStepParser.invoke(
-                            new StepParser.Context(this, mapper, step.node, resolver),
+                            new StepParser.Context(this, null, mapper, step.node, resolver),
                             step.id);
                     }
                 }

--- a/camel-k-loader-yaml/camel-k-loader-yaml/src/test/groovy/org/apache/camel/k/loader/yaml/RoutesTest.groovy
+++ b/camel-k-loader-yaml/camel-k-loader-yaml/src/test/groovy/org/apache/camel/k/loader/yaml/RoutesTest.groovy
@@ -142,4 +142,21 @@ class RoutesTest extends TestSupport {
         cleanup:
             context?.stop()
     }
+
+    def 'errorHandler'() {
+        setup:
+            def context = startContext([
+                'myFailingProcessor' : new MyFailingProcessor()
+            ])
+
+            mockEndpoint(context, 'mock:on-error') {
+                expectedMessageCount = 1
+            }
+        when:
+            context.createProducerTemplate().requestBody('direct:start', 'Hello World');
+        then:
+            MockEndpoint.assertIsSatisfied(context)
+        cleanup:
+            context?.stop()
+    }
 }

--- a/camel-k-loader-yaml/camel-k-loader-yaml/src/test/groovy/org/apache/camel/k/loader/yaml/TestSupport.groovy
+++ b/camel-k-loader-yaml/camel-k-loader-yaml/src/test/groovy/org/apache/camel/k/loader/yaml/TestSupport.groovy
@@ -26,6 +26,7 @@ import org.apache.camel.k.loader.yaml.spi.ProcessorStepParser
 import org.apache.camel.k.loader.yaml.spi.StartStepParser
 import org.apache.camel.k.loader.yaml.spi.StepParser
 import org.apache.camel.model.ProcessorDefinition
+import org.apache.camel.model.RouteDefinition
 import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
@@ -43,7 +44,7 @@ class TestSupport extends Specification {
             }
         }
 
-        return new StepParser.Context(builder, MAPPER, node, RESOLVER)
+        return new StepParser.Context(builder, new RouteDefinition(), MAPPER, node, RESOLVER)
     }
 
     static StepParser.Context stepContext(JsonNode content) {
@@ -53,7 +54,7 @@ class TestSupport extends Specification {
             }
         }
 
-        return new StepParser.Context(builder, MAPPER, content, RESOLVER)
+        return new StepParser.Context(builder, new RouteDefinition(), MAPPER, content, RESOLVER)
     }
 
     static CamelContext startContext(String content) {
@@ -117,6 +118,10 @@ class TestSupport extends Specification {
 
     static <U extends ProcessorStepParser> ProcessorDefinition<?> toProcessor(Class<U> type, String content) {
         return type.getConstructor().newInstance().toProcessor(stepContext(content))
+    }
+
+    static <U extends StartStepParser> ProcessorDefinition<?> toStartProcessor(Class<U> type, String content) {
+        return type.getConstructor().newInstance().toStartProcessor(stepContext(content))
     }
 
     static ProcessorDefinition<?> toProcessor(String id, String content) {

--- a/camel-k-loader-yaml/camel-k-loader-yaml/src/test/groovy/org/apache/camel/k/loader/yaml/parser/ErrorHandlerTest.groovy
+++ b/camel-k-loader-yaml/camel-k-loader-yaml/src/test/groovy/org/apache/camel/k/loader/yaml/parser/ErrorHandlerTest.groovy
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.k.loader.yaml.parser
+
+import org.apache.camel.builder.DeadLetterChannelBuilder
+import org.apache.camel.builder.DefaultErrorHandlerBuilder
+import org.apache.camel.builder.ErrorHandlerBuilderRef
+import org.apache.camel.builder.NoErrorHandlerBuilder
+import org.apache.camel.k.loader.yaml.TestSupport
+import org.apache.camel.model.RouteDefinition
+
+class ErrorHandlerTest extends TestSupport {
+    def "definition (route/no-error-handler)"() {
+        when:
+            def processor = toProcessor(ErrorHandlerStepParser, '''
+                 no-error-handler: {}                 
+            ''')
+        then:
+            with(processor, RouteDefinition) {
+                errorHandlerFactory instanceof NoErrorHandlerBuilder
+            }
+    }
+
+    def "definition (route/default)"() {
+        when:
+            def processor = toProcessor(ErrorHandlerStepParser, '''
+                 default:
+                   dead-letter-uri: "jms:queue:dead"   
+            ''')
+        then:
+            with(processor, RouteDefinition) {
+                with(errorHandlerFactory, DefaultErrorHandlerBuilder) {
+                    deadLetterUri == 'jms:queue:dead'
+                }
+            }
+    }
+
+    def "definition (route/dead-letter-channel)"() {
+        when:
+            def processor = toProcessor(ErrorHandlerStepParser, '''
+                 dead-letter-channel: "jms:queue:dead"  
+            ''')
+        then:
+            with(processor, RouteDefinition) {
+                with(errorHandlerFactory, DeadLetterChannelBuilder) {
+                    deadLetterUri == 'jms:queue:dead'
+                }
+            }
+    }
+
+    def "definition (route/ref)"() {
+        when:
+            def processor = toProcessor(ErrorHandlerStepParser, '''
+                 ref: "myErrorHandler"                 
+            ''')
+        then:
+            with(processor, RouteDefinition) {
+                with(errorHandlerFactory, ErrorHandlerBuilderRef) {
+                    ref == 'myErrorHandler'
+                }
+            }
+    }
+
+    def "definition (global/no-error-handler)"() {
+        given:
+            def stepContext = stepContext('''
+                 no-error-handler: {}                 
+            ''')
+        when:
+            new ErrorHandlerStepParser().toStartProcessor(stepContext)
+        then:
+            stepContext.builder().routeCollection.errorHandlerFactory instanceof NoErrorHandlerBuilder
+    }
+
+    def "definition (global/default)"() {
+        given:
+            def stepContext = stepContext('''
+                 default:
+                   dead-letter-uri: "jms:queue:dead"        
+            ''')
+        when:
+            new ErrorHandlerStepParser().toStartProcessor(stepContext)
+        then:
+            with(stepContext.builder().routeCollection.errorHandlerFactory, DefaultErrorHandlerBuilder) {
+                deadLetterUri == 'jms:queue:dead'
+            }
+    }
+
+    def "definition (global/dead-letter-channel)"() {
+        given:
+            def stepContext = stepContext('''
+                 dead-letter-channel: "jms:queue:dead"        
+            ''')
+        when:
+            new ErrorHandlerStepParser().toStartProcessor(stepContext)
+        then:
+            with(stepContext.builder().routeCollection.errorHandlerFactory, DefaultErrorHandlerBuilder) {
+                deadLetterUri == 'jms:queue:dead'
+            }
+    }
+
+    def "definition (global/ref)"() {
+        given:
+            def stepContext = stepContext('''
+                 ref: "myErrorHandler"          
+            ''')
+        when:
+            new ErrorHandlerStepParser().toStartProcessor(stepContext)
+        then:
+            with(stepContext.builder().routeCollection.errorHandlerFactory, ErrorHandlerBuilderRef) {
+                ref == 'myErrorHandler'
+            }
+    }
+}

--- a/camel-k-loader-yaml/camel-k-loader-yaml/src/test/resources/routes/RoutesTest_errorHandler.yaml
+++ b/camel-k-loader-yaml/camel-k-loader-yaml/src/test/resources/routes/RoutesTest_errorHandler.yaml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+- error-handler:
+    dead-letter-channel:
+      dead-letter-uri: "mock:on-error"
+      redelivery-delay: 0
+- from:
+    uri: "direct:start"
+    steps:
+      - process:
+          ref: "myFailingProcessor"

--- a/tooling/camel-k-annotations/src/main/java/org/apache/camel/k/annotation/yaml/YAMLNodeDefinition.java
+++ b/tooling/camel-k-annotations/src/main/java/org/apache/camel/k/annotation/yaml/YAMLNodeDefinition.java
@@ -21,10 +21,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.apache.camel.reifier.ProcessorReifier;
+import org.apache.camel.reifier.AbstractReifier;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface YAMLNodeDefinition {
-    Class<? extends ProcessorReifier>[] reifiers() default {};
+    Class<? extends AbstractReifier>[] reifiers() default {};
 }


### PR DESCRIPTION
Fixes #339

There some limitations now as the underlying builders do not provide
`xyzRef` fields so it is not actually possible to add processors like
`onExceptionOccurred` but those capabilities are present in the xml
DSL so we may need to revisit Error Handler support to add the same
level of integration.