### PR TITLE
loaders: add itest for kotlin on quarkus

### DIFF
--- a/camel-k-quarkus/camel-k-quarkus-itests/camel-k-quarkus-itests-loader-kotlin/pom.xml
+++ b/camel-k-quarkus/camel-k-quarkus-itests/camel-k-quarkus-itests-loader-kotlin/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.k</groupId>
+        <artifactId>camel-k-quarkus-itests</artifactId>
+        <version>1.5.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-k-quarkus-itests-loader-kotlin</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-quarkus-loader-kotlin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-direct</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-quarkus-itests-loader-support</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${build-helper-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>reserve-network-port</id>
+                        <goals>
+                            <goal>reserve-network-port</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <portNames>
+                                <portName>test.http.port.jvm</portName>
+                                <portName>test.http.port.native</portName>
+                            </portNames>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/camel-k-quarkus/camel-k-quarkus-itests/camel-k-quarkus-itests-loader-kotlin/src/main/java/org/apache/camel/k/loader/kotlin/quarkus/Application.java
+++ b/camel-k-quarkus/camel-k-quarkus-itests/camel-k-quarkus-itests-loader-kotlin/src/main/java/org/apache/camel/k/loader/kotlin/quarkus/Application.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.k.loader.kotlin.quarkus;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.json.JsonObject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Consume;
+import org.apache.camel.k.loader.support.LoaderSupport;
+
+@Path("/test")
+@ApplicationScoped
+public class Application {
+    @Inject
+    CamelContext context;
+
+    @POST
+    @Path("/load-routes/{name}")
+    @Consume(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject loadRoutes(@PathParam("name") String name, String code) throws Exception {
+        return LoaderSupport.inspectSource(context, name, "kts", code);
+    }
+}

--- a/camel-k-quarkus/camel-k-quarkus-itests/camel-k-quarkus-itests-loader-kotlin/src/main/resources/application.properties
+++ b/camel-k-quarkus/camel-k-quarkus-itests/camel-k-quarkus-itests-loader-kotlin/src/main/resources/application.properties
@@ -1,0 +1,27 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+#
+# Quarkus
+#
+quarkus.log.console.enable = true
+quarkus.banner.enabled     = false
+
+#
+# Quarkus :: Camel
+#
+quarkus.camel.routes-discovery.enabled = false

--- a/camel-k-quarkus/camel-k-quarkus-itests/camel-k-quarkus-itests-loader-kotlin/src/test/java/org/apache/camel/k/loader/kotlin/quarkus/KotlinLoaderTest.java
+++ b/camel-k-quarkus/camel-k-quarkus-itests/camel-k-quarkus-itests-loader-kotlin/src/test/java/org/apache/camel/k/loader/kotlin/quarkus/KotlinLoaderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.k.loader.kotlin.quarkus;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.test.junit.DisabledOnNativeImage;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+import org.apache.camel.util.IOHelper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Disabled("https://github.com/quarkusio/quarkus/issues/11549")
+@DisabledOnNativeImage
+@QuarkusTest
+public class KotlinLoaderTest {
+    @Test
+    public void testLoadRoutes() throws IOException {
+        String code;
+
+        try (InputStream is = KotlinLoaderTest.class.getResourceAsStream("/routes.kts")) {
+            code = IOHelper.loadText(is);
+        }
+
+        JsonPath p = RestAssured.given()
+            .contentType(MediaType.TEXT_PLAIN)
+            .accept(MediaType.APPLICATION_JSON)
+            .body(code)
+            .post("/test/load-routes/MyRoute")
+            .then()
+                .statusCode(200)
+            .extract()
+                .body()
+                .jsonPath();
+
+        assertThat(p.getList("components", String.class)).contains("direct", "log");
+        assertThat(p.getList("routes", String.class)).contains("kotlin");
+        assertThat(p.getList("endpoints", String.class)).contains("direct://kotlin", "log://kotlin");
+    }
+}

--- a/camel-k-quarkus/camel-k-quarkus-itests/camel-k-quarkus-itests-loader-kotlin/src/test/resources/routes.kts
+++ b/camel-k-quarkus/camel-k-quarkus-itests/camel-k-quarkus-itests-loader-kotlin/src/test/resources/routes.kts
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+from("direct:kotlin")
+    .routeId("kotlin")
+    .to("log:kotlin")

--- a/camel-k-quarkus/camel-k-quarkus-itests/pom.xml
+++ b/camel-k-quarkus/camel-k-quarkus-itests/pom.xml
@@ -34,6 +34,7 @@
         <module>camel-k-quarkus-itests-knative</module>
         <module>camel-k-quarkus-itests-loader-support</module>
         <module>camel-k-quarkus-itests-loader-groovy</module>
+        <module>camel-k-quarkus-itests-loader-kotlin</module>
         <module>camel-k-quarkus-itests-loader-java</module>
         <module>camel-k-quarkus-itests-loader-js</module>
         <module>camel-k-quarkus-itests-loader-xml</module>

--- a/camel-k-quarkus/camel-k-quarkus-loader-kotlin/deployment/pom.xml
+++ b/camel-k-quarkus/camel-k-quarkus-loader-kotlin/deployment/pom.xml
@@ -36,11 +36,6 @@
             <groupId>org.apache.camel.k</groupId>
             <artifactId>camel-k-quarkus-loader-kotlin</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-kotlin-deployment</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/camel-k-quarkus/camel-k-quarkus-loader-kotlin/pom.xml
+++ b/camel-k-quarkus/camel-k-quarkus-loader-kotlin/pom.xml
@@ -28,6 +28,18 @@
 
     <artifactId>camel-k-quarkus-loader-kotlin-parent</artifactId>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>runtime</module>
         <module>deployment</module>

--- a/camel-k-quarkus/camel-k-quarkus-loader-kotlin/runtime/pom.xml
+++ b/camel-k-quarkus/camel-k-quarkus-loader-kotlin/runtime/pom.xml
@@ -27,31 +27,14 @@
 
     <artifactId>camel-k-quarkus-loader-kotlin</artifactId>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-bom</artifactId>
-                <version>${kotlin.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.k</groupId>
             <artifactId>camel-k-loader-kotlin</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.camel.k</groupId>
             <artifactId>camel-k-quarkus-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-kotlin</artifactId>
         </dependency>
     </dependencies>
 

--- a/camel-k-quarkus/pom.xml
+++ b/camel-k-quarkus/pom.xml
@@ -31,6 +31,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-bom</artifactId>
                 <version>${camel-quarkus.version}</version>

--- a/examples/camel-k-runtime-example-quarkus-kotlin/pom.xml
+++ b/examples/camel-k-runtime-example-quarkus-kotlin/pom.xml
@@ -36,6 +36,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-bom</artifactId>
                 <version>${camel-quarkus.version}</version>


### PR DESCRIPTION
Test is currently disabled because of https://github.com/quarkusio/quarkus/issues/11549


<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```