### PR TITLE
kamelet: ensure properties are correctly propagated to the route template engine

### DIFF
--- a/components/camel-kamelet/pom.xml
+++ b/components/camel-kamelet/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>camel-test-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-http</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/KameletComponent.java
+++ b/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/KameletComponent.java
@@ -35,6 +35,7 @@ import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
 import org.apache.camel.support.LifecycleStrategySupport;
 import org.apache.camel.support.service.ServiceHelper;
+import org.apache.camel.util.URISupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,6 +121,14 @@ public class KameletComponent extends DefaultComponent {
 
             // set endpoint specific properties
             setProperties(endpoint, parameters);
+
+            // determine the parameters that the kamelet should take by using the original
+            // uri as we need to preserve the original format.
+            final String query = URISupport.extractQuery(uri);
+            final Map<String, Object> queryParams = URISupport.parseQuery(query, true, true);
+
+            // replace resolved params with the original ones
+            parameters.replaceAll(queryParams::getOrDefault);
 
             //
             // The properties for the kamelets are determined by global properties


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```