### PR TITLE
Fix #536: enable knative:event endpoints without path

### DIFF
--- a/components/camel-knative/camel-knative/src/main/java/org/apache/camel/component/knative/KnativeEndpoint.java
+++ b/components/camel-knative/camel-knative/src/main/java/org/apache/camel/component/knative/KnativeEndpoint.java
@@ -199,7 +199,7 @@ public class KnativeEndpoint extends DefaultEndpoint {
         // For event type endpoints se need to add an additional filter to filter out events received
         // based on the given type.
         //
-        if (resource.getType() == Knative.Type.event) {
+        if (resource.getType() == Knative.Type.event && ObjectHelper.isNotEmpty(resourceName)) {
             answer.setCloudEventType(resourceName);
             answer.addFilter(CloudEvent.CAMEL_CLOUD_EVENT_TYPE, resourceName);
         }


### PR DESCRIPTION
<!-- Description -->

Fix #536


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
