### PR TITLE
Support fast-jar packaging for quarkus

### DIFF
--- a/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
@@ -19,7 +19,7 @@ new File(basedir, "catalog.yaml").withReader {
     def catalog = new groovy.yaml.YamlSlurper().parse(it)
 
     assert catalog.spec.runtime.version == runtimeVersion
-    assert catalog.spec.runtime.applicationClass == 'io.quarkus.runner.GeneratedMain'
+    assert catalog.spec.runtime.applicationClass == 'io.quarkus.bootstrap.runner.QuarkusEntryPoint'
     assert catalog.spec.runtime.metadata['camel.version'] == camelVersion
     assert catalog.spec.runtime.metadata['quarkus.version'] == quarkusVersion
     assert catalog.spec.runtime.metadata['camel-quarkus.version'] == camelQuarkusVersion

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
@@ -112,7 +112,7 @@ public class GenerateCatalogMojo extends AbstractMojo {
                 "org.apache.camel.quarkus", "camel-quarkus-catalog",
                 version -> runtimeSpec.putMetadata("camel-quarkus.version", version));
 
-            runtimeSpec.applicationClass("io.quarkus.runner.GeneratedMain");
+            runtimeSpec.applicationClass("io.quarkus.bootstrap.runner.QuarkusEntryPoint");
             runtimeSpec.addDependency("org.apache.camel.k", "camel-k-runtime");
             runtimeSpec.putCapability(
                 "cron",


### PR DESCRIPTION
<!-- Description -->
prerequisite for https://github.com/apache/camel-k/pull/1931.

I set the itests to use fast-jar. Not sure if that's entirely necessary, so I can drop that commit if necessary.



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
