### PR TITLE
Revert "Support fast-jar packaging for quarkus"

### DIFF
--- a/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
@@ -19,7 +19,7 @@ new File(basedir, "catalog.yaml").withReader {
     def catalog = new groovy.yaml.YamlSlurper().parse(it)
 
     assert catalog.spec.runtime.version == runtimeVersion
-    assert catalog.spec.runtime.applicationClass == 'io.quarkus.bootstrap.runner.QuarkusEntryPoint'
+    assert catalog.spec.runtime.applicationClass == 'io.quarkus.runner.GeneratedMain'
     assert catalog.spec.runtime.metadata['camel.version'] == camelVersion
     assert catalog.spec.runtime.metadata['quarkus.version'] == quarkusVersion
     assert catalog.spec.runtime.metadata['camel-quarkus.version'] == camelQuarkusVersion

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
@@ -112,7 +112,7 @@ public class GenerateCatalogMojo extends AbstractMojo {
                 "org.apache.camel.quarkus", "camel-quarkus-catalog",
                 version -> runtimeSpec.putMetadata("camel-quarkus.version", version));
 
-            runtimeSpec.applicationClass("io.quarkus.bootstrap.runner.QuarkusEntryPoint");
+            runtimeSpec.applicationClass("io.quarkus.runner.GeneratedMain");
             runtimeSpec.addDependency("org.apache.camel.k", "camel-k-runtime");
             runtimeSpec.putCapability(
                 "cron",


### PR DESCRIPTION
When the fix for https://github.com/quarkusio/quarkus/issues/14583 is available via camel-quarkus I'll redo this change. 