### PR TITLE
fix(runtime): singleton config source provider

### DIFF
--- a/camel-k-runtime/runtime/src/main/java/org/apache/camel/k/quarkus/ApplicationConfigSourceProvider.java
+++ b/camel-k-runtime/runtime/src/main/java/org/apache/camel/k/quarkus/ApplicationConfigSourceProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.k.quarkus;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -23,16 +24,59 @@ import io.smallrye.config.PropertiesConfigSource;
 import org.apache.camel.k.support.RuntimeSupport;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ApplicationConfigSourceProvider implements ConfigSourceProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationConfigSourceProvider.class);
+
     @Override
     public Iterable<ConfigSource> getConfigSources(ClassLoader forClassLoader) {
-        final Map<String, String> appProperties = RuntimeSupport.loadApplicationProperties();
-        final Map<String, String> usrProperties = RuntimeSupport.loadUserProperties();
-
-        return List.of(
-            new PropertiesConfigSource(appProperties, "camel-k-app", ConfigSource.DEFAULT_ORDINAL),
-            new PropertiesConfigSource(usrProperties, "camel-k-usr", ConfigSource.DEFAULT_ORDINAL + 1)
-        );
+        LOGGER.debug("Getting config sources for class loader {}", forClassLoader);
+        return ApplicationConfigSourceHolder.getProperties();
     }
+
+    /**
+     * We use this singleton class in order to workaround the fact that Quarkus runtime may call the ConfigSourceProvider twice by
+     * runtime classloader (see https://github.com/quarkusio/quarkus/issues/8145). To fix when it's solved by Quarkus.
+     */
+    private static final class ApplicationConfigSourceHolder {
+        private static final String RUNTIME_CLASS = "io.quarkus.deployment.steps.RuntimeConfigSetup";
+        private static final ApplicationConfigSourceHolder INSTANCE = new ApplicationConfigSourceHolder();
+        private final List<ConfigSource> runtimeProperties;
+
+        private ApplicationConfigSourceHolder() {
+            if (isRuntimePhase()) {
+                this.runtimeProperties = fetchProperties();
+            } else {
+                LOGGER.debug("Skipping config source fetching during deployment phase");
+                this.runtimeProperties = Collections.emptyList();
+            }
+        }
+
+        public static List<ConfigSource> getProperties() {
+            return INSTANCE.runtimeProperties;
+        }
+
+        private List<ConfigSource> fetchProperties() {
+            LOGGER.debug("Fetching application and user properties");
+            final Map<String, String> appProperties = RuntimeSupport.loadApplicationProperties();
+            final Map<String, String> usrProperties = RuntimeSupport.loadUserProperties();
+
+            return List.of(
+                    new PropertiesConfigSource(appProperties, "camel-k-app", ConfigSource.DEFAULT_ORDINAL),
+                    new PropertiesConfigSource(usrProperties, "camel-k-usr", ConfigSource.DEFAULT_ORDINAL + 1)
+            );
+        }
+
+        private boolean isRuntimePhase() {
+            try {
+                Class.forName(RUNTIME_CLASS);
+                return true;
+            } catch (ClassNotFoundException e) {
+                return false;
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Created a singleton to workaround an issue on Quarkus side which is calling the method twice at runtime.

Ref #625

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(runtime): singleton config source provider
```
