### PR TITLE
Missing camel-k-kamelet-reify version while building kamelet binding

### DIFF
--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -226,6 +226,11 @@
                 <artifactId>camel-k-loader-groovy</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-kamelet-reify</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.camel.k</groupId>


### PR DESCRIPTION
Fix #655 

**Release Note**
```release-note
NONE
```
