### PR TITLE
Add quarkus:dev option for running the examples

### DIFF
--- a/examples/cron/README.md
+++ b/examples/cron/README.md
@@ -8,7 +8,7 @@ The route involves log and timer components
 
 - Plain
 
-You have two ways of doing this.
+You have three ways of doing this.
 
 First approach:
 
@@ -25,6 +25,11 @@ Second approach
     export CAMEL_K_CONF=${project.basedir}/data/application.properties
     export CAMEL_K_ROUTES=file:${project.basedir}/data/routes.yaml?interceptors=cron
     java -jar target/quarkus-app/quarkus-run.jar
+```
+
+Third approach
+```
+    mvn clean compile quarkus:dev
 ```
 
 - Native
@@ -76,9 +81,9 @@ You should get the following output in both cases
 ## Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+[let us know](https://camel.apache.org/support.html).
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+[get involved](https://camel.apache.org/contributing.html) :-)
 
 The Camel riders!

--- a/examples/cron/pom.xml
+++ b/examples/cron/pom.xml
@@ -74,15 +74,20 @@
                 <version>${quarkus-version}</version>
                 <executions>
                     <execution>
-                        <id>build</id>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
                         </goals>
-                        <configuration>
-                            <finalName>${project.artifactId}</finalName>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <finalName>${project.artifactId}</finalName>
+                    <environmentVariables>
+                        <CAMEL_K_CONF>${project.basedir}/data/application.properties</CAMEL_K_CONF>
+                        <CAMEL_K_ROUTES>file:${project.basedir}/data/routes.yaml?interceptors=cron</CAMEL_K_ROUTES>
+                    </environmentVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/examples/groovy/pom.xml
+++ b/examples/groovy/pom.xml
@@ -66,15 +66,20 @@
                 <version>${quarkus-version}</version>
                 <executions>
                     <execution>
-                        <id>build</id>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
                         </goals>
-                        <configuration>
-                            <finalName>${project.artifactId}</finalName>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <finalName>${project.artifactId}</finalName>
+                    <environmentVariables>
+                        <CAMEL_K_CONF>${project.basedir}/data/application.properties</CAMEL_K_CONF>
+                        <CAMEL_K_ROUTES>file:${project.basedir}/data/routes.groovy</CAMEL_K_ROUTES>
+                    </environmentVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -6,7 +6,7 @@ The route involves timer component and log component.
 
 ## How to run
 
-You have two ways of doing this.
+You have three ways of doing this.
 
 First approach:
 
@@ -23,7 +23,12 @@ Second approach
     java -jar target/quarkus-app/quarkus-run.jar
 ```
 
-You should get the following output in both cases
+Third approach
+```
+    mvn clean compile quarkus:dev
+```
+
+You should get the following output in all three cases
 
 ```
     2021-02-08 18:25:50,700 INFO  [org.apa.cam.k.Runtime] (main) Apache Camel K Runtime 1.7.0-SNAPSHOT

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -66,15 +66,20 @@
                 <version>${quarkus-version}</version>
                 <executions>
                     <execution>
-                        <id>build</id>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
                         </goals>
-                        <configuration>
-                            <finalName>${project.artifactId}</finalName>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <finalName>${project.artifactId}</finalName>
+                    <environmentVariables>
+                        <CAMEL_K_CONF>${project.basedir}/data/application.properties</CAMEL_K_CONF>
+                        <CAMEL_K_ROUTES>file:${project.basedir}/data/MyRoutes.java</CAMEL_K_ROUTES>
+                    </environmentVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/examples/js/pom.xml
+++ b/examples/js/pom.xml
@@ -66,15 +66,20 @@
                 <version>${quarkus-version}</version>
                 <executions>
                     <execution>
-                        <id>build</id>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
                         </goals>
-                        <configuration>
-                            <finalName>${project.artifactId}</finalName>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <finalName>${project.artifactId}</finalName>
+                    <environmentVariables>
+                        <CAMEL_K_CONF>${project.basedir}/data/application.properties</CAMEL_K_CONF>
+                        <CAMEL_K_ROUTES>file:${project.basedir}/data/routes.js</CAMEL_K_ROUTES>
+                    </environmentVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/examples/kafka-source-s3/README.md
+++ b/examples/kafka-source-s3/README.md
@@ -13,7 +13,7 @@ Fill correctly the application.properties file.
 
 ## How to run
 
-You have two ways of doing this.
+You have three ways of doing this.
 
 First approach:
 
@@ -32,7 +32,12 @@ Second approach
     java -jar target/quarkus-app/quarkus-run.jar
 ```
 
-You should get the following output in both cases
+Third approach
+```
+    mvn clean compile quarkus:dev
+```
+
+You should get the following output all three cases
 
 ```
 2021-02-09 08:27:13,463 INFO  [org.apa.cam.k.Runtime] (main) Apache Camel K Runtime 1.7.0-SNAPSHOT

--- a/examples/kafka-source-s3/pom.xml
+++ b/examples/kafka-source-s3/pom.xml
@@ -66,15 +66,20 @@
                 <version>${quarkus-version}</version>
                 <executions>
                     <execution>
-                        <id>build</id>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
                         </goals>
-                        <configuration>
-                            <finalName>${project.artifactId}</finalName>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <finalName>${project.artifactId}</finalName>
+                    <environmentVariables>
+                        <CAMEL_K_CONF>${project.basedir}/data/application.properties</CAMEL_K_CONF>
+                        <CAMEL_K_ROUTES>file:${project.basedir}/data/MyRoutes.java</CAMEL_K_ROUTES>
+                    </environmentVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/examples/kamelets/pom.xml
+++ b/examples/kamelets/pom.xml
@@ -71,11 +71,17 @@
                     <execution>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
                         </goals>
                     </execution>
                 </executions>
                 <configuration>
                     <finalName>${project.artifactId}</finalName>
+                    <environmentVariables>
+                        <CAMEL_K_CONF>${project.basedir}/data/application.properties</CAMEL_K_CONF>
+                        <DATA_DIR>${project.basedir}/data</DATA_DIR>
+                    </environmentVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/examples/knative/pom.xml
+++ b/examples/knative/pom.xml
@@ -75,11 +75,18 @@
                     <execution>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
                         </goals>
                     </execution>
                 </executions>
                 <configuration>
                     <finalName>${project.artifactId}</finalName>
+                    <environmentVariables>
+                        <CAMEL_K_CONF>${project.basedir}/data/application.properties</CAMEL_K_CONF>
+                        <CAMEL_K_ROUTES>file:${project.basedir}/data/routes.yaml</CAMEL_K_ROUTES>
+                        <CAMEL_KNATIVE_CONFIGURATION>file:${project.basedir}/data/env.json</CAMEL_KNATIVE_CONFIGURATION>
+                    </environmentVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/examples/kotlin/pom.xml
+++ b/examples/kotlin/pom.xml
@@ -65,15 +65,20 @@
                 <version>${quarkus-version}</version>
                 <executions>
                     <execution>
-                        <id>build</id>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
                         </goals>
-                        <configuration>
-                            <finalName>${project.artifactId}</finalName>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <finalName>${project.artifactId}</finalName>
+                    <environmentVariables>
+                        <CAMEL_K_CONF>${project.basedir}/data/application.properties</CAMEL_K_CONF>
+                        <CAMEL_K_ROUTES>file:${project.basedir}/data/routes.kts</CAMEL_K_ROUTES>
+                    </environmentVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/examples/xml/pom.xml
+++ b/examples/xml/pom.xml
@@ -65,15 +65,20 @@
                 <version>${quarkus-version}</version>
                 <executions>
                     <execution>
-                        <id>build</id>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
                         </goals>
-                        <configuration>
-                            <finalName>${project.artifactId}</finalName>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <finalName>${project.artifactId}</finalName>
+                    <environmentVariables>
+                        <CAMEL_K_CONF>${project.basedir}/data/application.properties</CAMEL_K_CONF>
+                        <CAMEL_K_ROUTES>file:${project.basedir}/data/routes.xml</CAMEL_K_ROUTES>
+                    </environmentVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/examples/yaml/pom.xml
+++ b/examples/yaml/pom.xml
@@ -69,15 +69,21 @@
                 <version>${quarkus-version}</version>
                 <executions>
                     <execution>
-                        <id>build</id>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
                         </goals>
-                        <configuration>
-                            <finalName>${project.artifactId}</finalName>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <finalName>${project.artifactId}</finalName>
+                    <environmentVariables>
+                        <CAMEL_K_CONF>${project.basedir}/data/application.properties</CAMEL_K_CONF>
+                        <CAMEL_K_CONF_D>${project.basedir}/data/conf.d</CAMEL_K_CONF_D>
+                        <CAMEL_K_ROUTES>file:${project.basedir}/data/routes.yaml</CAMEL_K_ROUTES>
+                    </environmentVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
<!-- Description -->
Based on [comment](https://github.com/apache/camel-k-runtime/pull/643#issuecomment-804727535) - adding the option to run the examples using:

`mvn clean compile quarkus:dev`

@lburgazzoli there seems to be a problem with the java example, which doesn't seem to run using the above mentioned command - there seems to be a problem with classloading, the problem is:

```
2021-04-16 13:51:22,023 ERROR [org.apa.cam.qua.mai.CamelMainRuntime] (Quarkus Main Thread) Failed to start application: org.apache.camel.RuntimeCamelException: org.joor.ReflectException: Compilation error: /MyRoutes.java:17: error: package org.apache.camel.builder does not exist
import org.apache.camel.builder.RouteBuilder;
                               ^
/MyRoutes.java:19: error: cannot find symbol
public class MyRoutes extends RouteBuilder {
                              ^
  symbol: class RouteBuilder
2 errors
```

I couldn't find the cause of this issue, I can however remove the option from this example, in case there is no easy solution.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->



**Release Note**
```release-note
NONE
```
