### PR TITLE
GH action fixes

### DIFF
--- a/.github/workflows/ci-build-camel-main.yaml
+++ b/.github/workflows/ci-build-camel-main.yaml
@@ -59,12 +59,15 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-    - name: Build camel (main)
-      run: |
-        git clone --depth 1 --branch main https://github.com/apache/camel.git \
-          && cd camel \
-          && echo "Current Camel commit:" $(git rev-parse HEAD) \
-          && ./mvnw ${MAVEN_ARGS} clean install -Pfastinstall
+#  For the time being (Camel 3.10 + Camel Quarkus 1.9) we remain aligned to Camel 3.10
+#  because that's what Camel Quarkus depends on. After that, we can re-enable this.
+#  See: https://github.com/apache/camel-k-runtime/issues/669
+#    - name: Build camel (main)
+#      run: |
+#        git clone --depth 1 --branch main https://github.com/apache/camel.git \
+#          && cd camel \
+#          && echo "Current Camel commit:" $(git rev-parse HEAD) \
+#          && ./mvnw ${MAVEN_ARGS} clean install -Pfastinstall
     - name: Build camel-quarkus (camel-main)
       run: |
         git clone --depth 1 --branch camel-main https://github.com/apache/camel-quarkus.git \


### PR DESCRIPTION
Temporarily disable building Camel Main on camel-main branch due to alignment with Camel Quarkus 1.9


<!-- Description -->



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```