### PR TITLE
Adjust to use latest Camel Quarkus after they aligned w/ Camel 3.10

### DIFF
--- a/.github/workflows/ci-build-camel-main.yaml
+++ b/.github/workflows/ci-build-camel-main.yaml
@@ -35,7 +35,7 @@ on:
       - 'Jenkinsfile'
   pull_request:
     branches:
-      - camel-master
+      - camel-main
     paths-ignore:
       - '**.adoc'
       - 'KEYS'
@@ -68,11 +68,11 @@ jobs:
 #          && cd camel \
 #          && echo "Current Camel commit:" $(git rev-parse HEAD) \
 #          && ./mvnw ${MAVEN_ARGS} clean install -Pfastinstall
-    - name: Build camel-quarkus (camel-main)
+    - name: Build camel-quarkus (main)
       run: |
         git clone --depth 1 --branch main https://github.com/apache/camel-quarkus.git \
           && cd camel-quarkus \
           && echo "Current Camel Quarkus commit:" $(git rev-parse HEAD) \
-          && ./mvnw ${MAVEN_ARGS} clean install -Dquickly -s $(pwd)/settings-camel-3.7.0.xml
+          && ./mvnw ${MAVEN_ARGS} clean install -Dquickly
     - name: Build camel-k-runtime
-      run: ./mvnw ${MAVEN_ARGS} -Dcheckstyle.failOnViolation=true -Psourcecheck clean install
+      run: ./mvnw ${MAVEN_ARGS} -Dcheckstyle.failOnViolation=true -Psourcecheck clean verify

--- a/.github/workflows/ci-build-camel-main.yaml
+++ b/.github/workflows/ci-build-camel-main.yaml
@@ -70,7 +70,7 @@ jobs:
 #          && ./mvnw ${MAVEN_ARGS} clean install -Pfastinstall
     - name: Build camel-quarkus (camel-main)
       run: |
-        git clone --depth 1 --branch camel-main https://github.com/apache/camel-quarkus.git \
+        git clone --depth 1 --branch main https://github.com/apache/camel-quarkus.git \
           && cd camel-quarkus \
           && echo "Current Camel Quarkus commit:" $(git rev-parse HEAD) \
           && ./mvnw ${MAVEN_ARGS} clean install -Dquickly -s $(pwd)/settings-camel-3.7.0.xml

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,7 +27,6 @@ on:
   push:
     branches:
       - main
-      - camel-main
     paths-ignore:
       - '**.adoc'
       - 'KEYS'

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -27,7 +27,6 @@ on:
   pull_request:
     branches:
       - main
-      - camel-main
     paths-ignore:
       - '**.adoc'
       - 'KEYS'

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
         <camel-version>3.10.0</camel-version>
 
         <!-- quarkus -->
-        <camel-quarkus-version>1.9.0-SNAPSHOT</camel-quarkus-version>
+        <camel-quarkus-version>2.0.0-M1-SNAPSHOT</camel-quarkus-version>
         <graalvm-version>21.0.0</graalvm-version>
-        <quarkus-version>2.0.0.Alpha2</quarkus-version>
+        <quarkus-version>2.0.0.Alpha3</quarkus-version>
 
         <!-- camel-k -->
         <groovy-version>3.0.7</groovy-version>


### PR DESCRIPTION
<!-- Description -->
Camel Quarkus bumped to 2.x after aligning w/ Camel 3.10. So, adjusting it accordingly



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```