### PR TITLE
fix(core): default SourceType as source

### DIFF
--- a/camel-k-core/api/src/main/java/org/apache/camel/k/SourceDefinition.java
+++ b/camel-k-core/api/src/main/java/org/apache/camel/k/SourceDefinition.java
@@ -28,7 +28,8 @@ public class SourceDefinition implements IdAware {
     private String language;
     private String loader;
     private List<String> interceptors;
-    private SourceType type;
+    // Default as source type
+    private SourceType type = SourceType.source;
     private List<String> propertyNames;
     private String location;
     private byte[] content;

--- a/camel-k-core/support/src/main/java/org/apache/camel/k/listener/SourcesConfigurer.java
+++ b/camel-k-core/support/src/main/java/org/apache/camel/k/listener/SourcesConfigurer.java
@@ -17,6 +17,7 @@
 package org.apache.camel.k.listener;
 
 import java.util.Arrays;
+import java.util.Comparator;
 
 import org.apache.camel.k.Runtime;
 import org.apache.camel.k.SourceDefinition;
@@ -100,19 +101,7 @@ public class SourcesConfigurer extends AbstractPhaseListener {
             return;
         }
         // We must ensure the source order as defined in SourceType enum
-        Arrays.sort(sources,
-                (a, b) -> {
-                    if (a.getType() == null && b.getType() == null) {
-                        return 0;
-                    }
-                    if (a.getType() == null) {
-                        return SourceType.source.compareTo(b.getType());
-                    } else if (b.getType() == null) {
-                        return a.getType().compareTo(SourceType.source);
-                    } else {
-                        return a.getType().compareTo(b.getType());
-                    }
-                });
+        Arrays.sort(sources, Comparator.comparingInt(a -> a.getType().ordinal()));
     }
 
 }

--- a/camel-k-core/support/src/test/java/org/apache/camel/k/listener/SourceConfigurerTest.java
+++ b/camel-k-core/support/src/test/java/org/apache/camel/k/listener/SourceConfigurerTest.java
@@ -18,26 +18,26 @@ package org.apache.camel.k.listener;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.k.SourceType;
 import org.apache.camel.k.support.PropertiesSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.k.test.CamelKTestSupport.asProperties;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SourceConfigurerTest {
     @Test
     public void shouldLoadMultipleSources() {
         CamelContext context = new DefaultCamelContext();
         context.getPropertiesComponent().setInitialProperties(asProperties(
-                "camel.k.sources[0].name", "sourceName0",
-                "camel.k.sources[0].location", "classpath:MyTemplate1.java",
+                "camel.k.sources[0].name", "templateName",
+                "camel.k.sources[0].location", "classpath:MyTemplate.java",
                 "camel.k.sources[0].type", "template",
-                "camel.k.sources[1].name", "err1",
-                "camel.k.sources[1].location", "classpath:MyTemplate2.java",
-                "camel.k.sources[2].name", "err2",
-                "camel.k.sources[2].location", "classpath:Err2.java",
+                "camel.k.sources[1].name", "src",
+                "camel.k.sources[1].location", "classpath:MySrc.java",
+                "camel.k.sources[2].name", "err",
+                "camel.k.sources[2].location", "classpath:Err.java",
                 "camel.k.sources[2].type", "errorHandler"
         ));
 
@@ -56,7 +56,7 @@ public class SourceConfigurerTest {
     public void shouldFailOnMultipleErrorHandlers() {
         CamelContext context = new DefaultCamelContext();
         context.getPropertiesComponent().setInitialProperties(asProperties(
-                "camel.k.sources[0].name", "sourceName0",
+                "camel.k.sources[0].name", "templateName0",
                 "camel.k.sources[0].location", "classpath:MyTemplate1.java",
                 "camel.k.sources[0].type", "template",
                 "camel.k.sources[1].name", "err1",
@@ -82,12 +82,37 @@ public class SourceConfigurerTest {
     }
 
     @Test
+    public void shouldDefaultSourcesWithEmptyType() {
+        CamelContext context = new DefaultCamelContext();
+        context.getPropertiesComponent().setInitialProperties(asProperties(
+                "camel.k.sources[0].name", "source0",
+                "camel.k.sources[1].name", "source1",
+                "camel.k.sources[2].name", "source2",
+                "camel.k.sources[2].type", "source"
+        ));
+
+        SourcesConfigurer configuration = new SourcesConfigurer();
+
+        PropertiesSupport.bindProperties(
+                context,
+                configuration,
+                k -> k.startsWith(SourcesConfigurer.CAMEL_K_SOURCES_PREFIX),
+                SourcesConfigurer.CAMEL_K_PREFIX);
+
+        assertThat(configuration.getSources().length).isEqualTo(3);
+        assertThat(configuration.getSources()[0].getType()).isEqualTo(SourceType.source);
+        assertThat(configuration.getSources()[1].getType()).isEqualTo(SourceType.source);
+        assertThat(configuration.getSources()[2].getType()).isEqualTo(SourceType.source);
+    }
+
+    @Test
     public void shouldOrderSourcesByType() {
         CamelContext context = new DefaultCamelContext();
         context.getPropertiesComponent().setInitialProperties(asProperties(
                 "camel.k.sources[0].name", "template1",
                 "camel.k.sources[0].type", "template",
                 "camel.k.sources[1].name", "source1",
+                "camel.k.sources[1].type", "source",
                 "camel.k.sources[2].name", "source2",
                 "camel.k.sources[3].name", "errorHandler1",
                 "camel.k.sources[3].type", "errorHandler"
@@ -104,10 +129,14 @@ public class SourceConfigurerTest {
 
         assertThat(configuration.getSources().length).isEqualTo(4);
         assertThat(configuration.getSources()[0].getName()).isEqualTo("errorHandler1");
+        assertThat(configuration.getSources()[0].getType()).isEqualTo(SourceType.errorHandler);
         assertThat(configuration.getSources()[1].getName()).isEqualTo("template1");
+        assertThat(configuration.getSources()[1].getType()).isEqualTo(SourceType.template);
         // Order for the same type does not matter
         assertThat(configuration.getSources()[2].getName()).contains("source");
+        assertThat(configuration.getSources()[2].getType()).isEqualTo(SourceType.source);
         assertThat(configuration.getSources()[3].getName()).contains("source");
+        assertThat(configuration.getSources()[3].getType()).isEqualTo(SourceType.source);
     }
 
     @Test


### PR DESCRIPTION
Setting any empty SourceType as a source.

Closes #658
Closes https://github.com/apache/camel-k/issues/2223

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
