### PR TITLE
Fixed VertxWebRouterBuildItem router call modified in Vert.x 4

### DIFF
--- a/camel-k-knative/consumer/deployment/src/main/java/org/apache/camel/k/quarkus/knative/consumer/deployment/KnativeConsumerProcessor.java
+++ b/camel-k-knative/consumer/deployment/src/main/java/org/apache/camel/k/quarkus/knative/consumer/deployment/KnativeConsumerProcessor.java
@@ -34,7 +34,7 @@ public class KnativeConsumerProcessor {
         return new CamelRuntimeBeanBuildItem(
             KnativeConsumerFeature.FEATURE + "-customizer",
             ComponentCustomizer.class.getName(),
-            recorder.createKnativeConsumerFactoryCustomizer(router.getRouter())
+            recorder.createKnativeConsumerFactoryCustomizer(router.getHttpRouter())
         );
     }
 }


### PR DESCRIPTION
<!-- Description -->


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```