### PR TITLE
(Do not merge) Allow excluding components from the catalog.

### DIFF
--- a/support/camel-k-catalog/pom.xml
+++ b/support/camel-k-catalog/pom.xml
@@ -26,6 +26,10 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>camel-k-catalog</artifactId>
 
+    <properties>
+        <exclusion.list>qute</exclusion.list>
+    </properties>
+
     <build>
         <defaultGoal>generate-resources</defaultGoal>
         <plugins>

--- a/support/camel-k-maven-plugin/src/it/generate-catalog/pom.xml
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog/pom.xml
@@ -32,6 +32,7 @@
         <catalog.path>${project.basedir}</catalog.path>
         <catalog.runtime>quarkus</catalog.runtime>
         <catalog.file>catalog.yaml</catalog.file>
+        <exclusion.list>qute</exclusion.list>
     </properties>
 
     <build>

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/processors/CatalogProcessor3x.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/processors/CatalogProcessor3x.java
@@ -94,10 +94,11 @@ public class CatalogProcessor3x implements CatalogProcessor {
     }
 
     @Override
-    public void process(MavenProject project, CamelCatalog catalog, CamelCatalogSpec.Builder specBuilder) {
+    public void process(MavenProject project, CamelCatalog catalog, CamelCatalogSpec.Builder specBuilder,
+                        List<String> exclusions) {
         Map<String, CamelArtifact> artifacts = new TreeMap<>();
 
-        processComponents(catalog, artifacts);
+        processComponents(catalog, artifacts, exclusions);
         processLanguages(catalog, artifacts);
         processDataFormats(catalog, artifacts);
         processLoaders(specBuilder);
@@ -200,8 +201,10 @@ public class CatalogProcessor3x implements CatalogProcessor {
         );
     }
 
-    private static void processComponents(CamelCatalog catalog, Map<String, CamelArtifact> artifacts) {
+    private static void processComponents(CamelCatalog catalog, Map<String, CamelArtifact> artifacts, List<String> exclusions) {
         final Set<String> elements = new TreeSet<>(catalog.findComponentNames());
+
+        elements.removeAll(exclusions);
 
         for (String name : elements) {
             String json = catalog.componentJSonSchema(name);

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/support/CatalogProcessor.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/support/CatalogProcessor.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.k.tooling.maven.support;
 
+import java.util.List;
+
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.k.catalog.model.k8s.crd.CamelCatalogSpec;
 import org.apache.maven.project.MavenProject;
@@ -33,7 +35,8 @@ public interface CatalogProcessor {
 
     boolean accepts(CamelCatalog catalog);
 
-    void process(MavenProject project, CamelCatalog catalog, CamelCatalogSpec.Builder specBuilder);
+    void process(MavenProject project, CamelCatalog catalog, CamelCatalogSpec.Builder specBuilder,
+                 List<String> exclusions);
 
     default int getOrder() {
         return LOWEST;

--- a/support/camel-k-maven-plugin/src/test/java/org/apache/camel/k/tooling/maven/processors/CatalogProcessor3Test.java
+++ b/support/camel-k-maven-plugin/src/test/java/org/apache/camel/k/tooling/maven/processors/CatalogProcessor3Test.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.k.tooling.maven.processors;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.camel.catalog.CamelCatalog;
@@ -74,7 +75,7 @@ public class CatalogProcessor3Test extends AbstractCatalogProcessorTest {
         CamelCatalogSpec.Builder builder = new CamelCatalogSpec.Builder().runtime(runtime);
 
         assertThat(processor.accepts(catalog)).isTrue();
-        processor.process(new MavenProject(), catalog, builder);
+        processor.process(new MavenProject(), catalog, builder, Collections.emptyList());
 
         CamelCatalogSpec spec = builder.build();
         Map<String, CamelArtifact> artifactMap = spec.getArtifacts();
@@ -96,7 +97,7 @@ public class CatalogProcessor3Test extends AbstractCatalogProcessorTest {
         CamelCatalogSpec.Builder builder = new CamelCatalogSpec.Builder().runtime(runtime);
 
         assertThat(processor.accepts(catalog)).isTrue();
-        processor.process(new MavenProject(), catalog, builder);
+        processor.process(new MavenProject(), catalog, builder, Collections.emptyList());
 
         CamelCatalogSpec spec = builder.build();
         Map<String, CamelArtifact> artifactMap = spec.getArtifacts();


### PR DESCRIPTION
Work-around #677 by excluding certain components from the catalog until apache/camel-quarkus#2661 is implemented


<!-- Description -->
Just a temporary work-around, but let's wait for the discussions on Camel Quarkus before going this route.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```