### PR TITLE
(chores) Test code cleanup

### DIFF
--- a/camel-k-core/support/src/test/java/org/apache/camel/k/listener/PropertiesFunctionsConfigurerTest.java
+++ b/camel-k-core/support/src/test/java/org/apache/camel/k/listener/PropertiesFunctionsConfigurerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.k.listener;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.k.Runtime;
 import org.junit.jupiter.api.Test;
@@ -35,14 +36,17 @@ public class PropertiesFunctionsConfigurerTest {
             .isEqualTo("my-secret-property");
         assertThat(runtime.getCamelContext().resolvePropertyPlaceholders("{{secret:none/my-property:my-default-secret}}"))
             .isEqualTo("my-default-secret");
-        assertThatThrownBy(() -> runtime.getCamelContext().resolvePropertyPlaceholders("{{secret:none/my-property}}"))
+        CamelContext context = runtime.getCamelContext();
+
+        assertThatThrownBy(() -> context.resolvePropertyPlaceholders("{{secret:none/my-property}}"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("returned null value which is not allowed, from input");
 
         assertThat(runtime.getCamelContext().resolvePropertyPlaceholders("{{configmap:my-cm/my-property}}")).isEqualTo("my-cm-property");
         assertThat(runtime.getCamelContext().resolvePropertyPlaceholders("{{configmap:my-cm/my-property:my-default-cm}}"))
             .isEqualTo("my-default-cm");
-        assertThatThrownBy(() -> runtime.getCamelContext().resolvePropertyPlaceholders("{{configmap:none/my-property}}"))
+
+        assertThatThrownBy(() -> context.resolvePropertyPlaceholders("{{configmap:none/my-property}}"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("returned null value which is not allowed, from input");
 

--- a/camel-k-core/support/src/test/java/org/apache/camel/k/listener/SourceConfigurerTest.java
+++ b/camel-k-core/support/src/test/java/org/apache/camel/k/listener/SourceConfigurerTest.java
@@ -49,7 +49,7 @@ public class SourceConfigurerTest {
                 k -> k.startsWith(SourcesConfigurer.CAMEL_K_SOURCES_PREFIX),
                 SourcesConfigurer.CAMEL_K_PREFIX);
 
-        assertThat(configuration.getSources().length).isEqualTo(3);
+        assertThat(configuration.getSources()).hasSize(3);
     }
 
     @Test
@@ -75,7 +75,7 @@ public class SourceConfigurerTest {
                 k -> k.startsWith(SourcesConfigurer.CAMEL_K_SOURCES_PREFIX),
                 SourcesConfigurer.CAMEL_K_PREFIX);
 
-        assertThat(configuration.getSources().length).isEqualTo(3);
+        assertThat(configuration.getSources()).hasSize(3);
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             SourcesConfigurer.checkUniqueErrorHandler(configuration.getSources());
         }, "java.lang.IllegalArgumentException: Expected only one error handler source type, got 2");
@@ -102,7 +102,7 @@ public class SourceConfigurerTest {
                 SourcesConfigurer.CAMEL_K_PREFIX);
         SourcesConfigurer.sortSources(configuration.getSources());
 
-        assertThat(configuration.getSources().length).isEqualTo(4);
+        assertThat(configuration.getSources()).hasSize(4);
         assertThat(configuration.getSources()[0].getName()).isEqualTo("errorHandler1");
         assertThat(configuration.getSources()[1].getName()).isEqualTo("template1");
         // Order for the same type does not matter

--- a/camel-k-core/support/src/test/java/org/apache/camel/k/support/RuntimeSupportTest.java
+++ b/camel-k-core/support/src/test/java/org/apache/camel/k/support/RuntimeSupportTest.java
@@ -44,7 +44,7 @@ public class RuntimeSupportTest {
         List<ContextCustomizer> customizers = RuntimeSupport.configureContextCustomizers(context);
         assertThat(context.getName()).isNotEqualTo("from-registry");
         assertThat(context.getName()).isNotEqualTo("default");
-        assertThat(customizers).hasSize(0);
+        assertThat(customizers).isEmpty();
 
         Properties properties = new Properties();
         properties.setProperty("camel.k.customizer.name.enabled", "true");
@@ -65,7 +65,7 @@ public class RuntimeSupportTest {
         List<ContextCustomizer> customizers = RuntimeSupport.configureContextCustomizers(context);
         assertThat(context.getName()).isNotEqualTo("from-registry");
         assertThat(context.getName()).isNotEqualTo("default");
-        assertThat(customizers).hasSize(0);
+        assertThat(customizers).isEmpty();
 
         Properties properties = new Properties();
         properties.setProperty(Constants.PROPERTY_CAMEL_K_CUSTOMIZER, "name");
@@ -85,7 +85,7 @@ public class RuntimeSupportTest {
         assertThat(context.getName()).isNotEqualTo("from-registry");
         assertThat(context.getName()).isNotEqualTo("default");
         assertThat(context.isLoadTypeConverters()).isFalse();
-        assertThat(customizers).hasSize(0);
+        assertThat(customizers).isEmpty();
 
         Properties properties = new Properties();
         properties.setProperty("camel.k.customizer.name.enabled", "true");
@@ -113,7 +113,7 @@ public class RuntimeSupportTest {
         assertThat(context.getName()).isNotEqualTo("from-registry");
         assertThat(context.getName()).isNotEqualTo("default");
         assertThat(context.isLoadTypeConverters()).isFalse();
-        assertThat(customizers).hasSize(0);
+        assertThat(customizers).isEmpty();
 
         Properties properties = new Properties();
         properties.setProperty("customizer.name.enabled", "true");

--- a/camel-k-cron/impl/src/test/java/org/apache/camel/k/cron/CronTest.java
+++ b/camel-k-cron/impl/src/test/java/org/apache/camel/k/cron/CronTest.java
@@ -78,7 +78,7 @@ public class CronTest {
         mock.assertIsSatisfied();
 
         termination.await(10, TimeUnit.SECONDS);
-        assertThat(termination.getCount()).isEqualTo(0);
+        assertThat(termination.getCount()).isZero();
     }
 
     static Stream<Arguments> parameters() {

--- a/itests/camel-k-itests-core/src/test/java/org/apache/camel/k/core/quarkus/deployment/CoreTest.java
+++ b/itests/camel-k-itests-core/src/test/java/org/apache/camel/k/core/quarkus/deployment/CoreTest.java
@@ -18,17 +18,14 @@ package org.apache.camel.k.core.quarkus.deployment;
 
 import javax.ws.rs.core.MediaType;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
-import org.apache.camel.k.CompositeClassloader;
 import org.apache.camel.k.listener.ContextConfigurer;
 import org.apache.camel.k.listener.SourcesConfigurer;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
 public class CoreTest {


### PR DESCRIPTION
- Removed unused imports
- Use hasSize on assertions for array sizes for simplicity and to avoid NPEs
- Use isEmpty on assertions for size checks for simplicity
- Use isZero on assertions for count checks for simplicity
- Avoid chained calls when testing for throws to avoid false positives


<!-- Description -->
Cleanups ... mostly on test code



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```