### PR TITLE
Reintroduces Qute component

### DIFF
--- a/support/camel-k-catalog/pom.xml
+++ b/support/camel-k-catalog/pom.xml
@@ -26,10 +26,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>camel-k-catalog</artifactId>
 
-    <properties>
-        <exclusion.list>qute</exclusion.list>
-    </properties>
-
     <build>
         <defaultGoal>generate-resources</defaultGoal>
         <plugins>

--- a/support/camel-k-maven-plugin/src/it/generate-catalog/pom.xml
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog/pom.xml
@@ -32,7 +32,7 @@
         <catalog.path>${project.basedir}</catalog.path>
         <catalog.runtime>quarkus</catalog.runtime>
         <catalog.file>catalog.yaml</catalog.file>
-        <exclusion.list>qute</exclusion.list>
+        <!-- If needed, components can be excluded with the exclusion.list property -->
     </properties>
 
     <build>


### PR DESCRIPTION
<!-- Description -->
Reintroduces the Qute component after Camel Quarkus applied the fix discussed on apache/camel-quarkus#2701 and apache/camel-quarkus#2661.

Retains the ability to exclude components, introduced on commit 4585f3def81ef078bd233399ed8fc371bc050675, in case it is needed in the future.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```