### PR TITLE
Added quarkus-logging-json as a runtime dependency

### DIFF
--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
@@ -120,6 +120,7 @@ public class GenerateCatalogMojo extends AbstractMojo {
 
             runtimeSpec.applicationClass("io.quarkus.bootstrap.runner.QuarkusEntryPoint");
             runtimeSpec.addDependency("org.apache.camel.k", "camel-k-runtime");
+            runtimeSpec.addDependency("io.quarkus", "quarkus-logging-json");
             runtimeSpec.putCapability(
                 "cron",
                 CamelCapability.forArtifact(


### PR DESCRIPTION
As part of GH issue apache/camel-k#2541, moved the dependency to the
runtime to ensure it's always present, even with custom base images or other
customizations. This also allow us to manage the dependencies on a
single place instead of spreading them over the codebase.


<!-- Description -->



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```