### PR TITLE
camel quarkus 2.4.0

### DIFF
--- a/.github/workflows/ci-build-camel-main.yaml
+++ b/.github/workflows/ci-build-camel-main.yaml
@@ -49,10 +49,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         persist-credentials: false
-    - name: Set up JDK 11
-      uses: AdoptOpenJDK/install-jdk@v1
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v2
       with:
-        version: '11'
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -46,14 +46,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java:
+          - '11'
     steps:
     - uses: actions/checkout@v2
       with:
         persist-credentials: false
-    - name: Set up JDK 11
-      uses: AdoptOpenJDK/install-jdk@v1
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v2
       with:
-        version: '11'
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
     - name: Build camel-k-runtime
       run: ./mvnw -V -ntp clean install
     - name: Tar Maven Repo
@@ -69,15 +74,16 @@ jobs:
     strategy:
       matrix:
         java:
-          - '14'
+          - '17'
     steps:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
-      - name: Set up JDK - ${{ matrix.java }}
-        uses: AdoptOpenJDK/install-jdk@v1
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v2
         with:
-          version:  ${{ matrix.java }}
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
       - name: Build on ${{ matrix.java }}
         run: |
           ./mvnw ${MAVEN_ARGS} -B clean install

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -35,12 +35,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java:
+          - '11'
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: AdoptOpenJDK/install-jdk@v1
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v2
       with:
-        version: '11'
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
     - name: mvn package
       run: |
         ./mvnw ${MAVEN_ARGS} \

--- a/itests/camel-k-itests-loader-jsh/src/main/java/org/apache/camel/k/loader/jsh/quarkus/it/JshApplication.java
+++ b/itests/camel-k-itests-loader-jsh/src/main/java/org/apache/camel/k/loader/jsh/quarkus/it/JshApplication.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.k.loader.jsh.quarkus;
+package org.apache.camel.k.loader.jsh.quarkus.it;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;

--- a/itests/camel-k-itests-loader-jsh/src/test/java/org/apache/camel/k/loader/jsh/it/JshLoaderTest.java
+++ b/itests/camel-k-itests-loader-jsh/src/test/java/org/apache/camel/k/loader/jsh/it/JshLoaderTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.k.loader.jsh;
+package org.apache.camel.k.loader.jsh.it;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <maven-enforcer-plugin-version>3.0.0</maven-enforcer-plugin-version>
         <maven-resources-plugin-version>3.2.0</maven-resources-plugin-version>
         <maven-site-plugin-version>3.9.1</maven-site-plugin-version>
-        <maven-pmd-plugin-version>3.14.0</maven-pmd-plugin-version>
+        <maven-pmd-plugin-version>3.15.0</maven-pmd-plugin-version>
         <maven-plugin-plugin-version>3.6.1</maven-plugin-plugin-version>
         <maven-version>3.6.3</maven-version>
         <maven-plugin-tools-version>3.6.1</maven-plugin-tools-version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <exec-maven-plugin-version>3.0.0</exec-maven-plugin-version>
         <mycila-license-version>4.1</mycila-license-version>
         <maven-checkstyle-plugin-version>3.1.2</maven-checkstyle-plugin-version>
-        <maven-checkstyle-version>8.43</maven-checkstyle-version>
+        <maven-checkstyle-version>8.44</maven-checkstyle-version>
         <maven-gpg-plugin-version>3.0.1</maven-gpg-plugin-version>
         <maven-deploy-plugin-version>3.0.0-M1</maven-deploy-plugin-version>
         <maven-javadoc-plugin-version>3.3.1</maven-javadoc-plugin-version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <jandex-version>2.4.1.Final</jandex-version>
 
         <!-- plugins -->
-        <gmavenplus-plugin-version>1.12.1</gmavenplus-plugin-version>
+        <gmavenplus-plugin-version>1.13.0</gmavenplus-plugin-version>
         <maven-compiler-plugin-version>3.8.1</maven-compiler-plugin-version>
         <maven-surefire-plugin-version>3.0.0-M5</maven-surefire-plugin-version>
         <maven-remote-resources-plugin-version>1.7.0</maven-remote-resources-plugin-version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <maven-remote-resources-plugin-version>1.7.0</maven-remote-resources-plugin-version>
         <maven-failsafe-plugin-version>3.0.0-M5</maven-failsafe-plugin-version>
         <versions-maven-plugin-version>2.8.1</versions-maven-plugin-version>
-        <directory-maven-plugin-version>0.3.1</directory-maven-plugin-version>
+        <directory-maven-plugin-version>1.0.0</directory-maven-plugin-version>
         <exec-maven-plugin-version>3.0.0</exec-maven-plugin-version>
         <mycila-license-version>4.1</mycila-license-version>
         <maven-checkstyle-plugin-version>3.1.2</maven-checkstyle-plugin-version>
@@ -204,13 +204,13 @@
                     <groupId>org.jboss.jandex</groupId>
                     <artifactId>jandex-maven-plugin</artifactId>
                     <version>${jandex-maven-plugin-version}</version>
-                    <dependencies>                                                    
-                        <dependency>                                                   
-                            <groupId>org.jboss</groupId>   
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jboss</groupId>
                             <artifactId>jandex</artifactId>
                             <version>${jandex-version}</version>
-                        </dependency>                           
-                    </dependencies>   
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -264,25 +264,25 @@
                     <groupId>org.apache.camel</groupId>
                     <artifactId>camel-component-maven-plugin</artifactId>
                     <version>${camel-version}</version>
-                    <dependencies>                                                    
-                        <dependency>                                                   
-                            <groupId>org.jboss</groupId>   
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jboss</groupId>
                             <artifactId>jandex</artifactId>
                             <version>${jandex-version}</version>
-                        </dependency>                           
-                    </dependencies>   
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.camel</groupId>
                     <artifactId>camel-package-maven-plugin</artifactId>
                     <version>${camel-version}</version>
-                    <dependencies>                                                    
-                        <dependency>                                                   
-                            <groupId>org.jboss</groupId>   
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jboss</groupId>
                             <artifactId>jandex</artifactId>
                             <version>${jandex-version}</version>
-                        </dependency>                           
-                    </dependencies>   
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.gmavenplus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -382,6 +382,7 @@
     </modules>
 
     <repositories>
+        <!--
         <repository>
             <id>camel.quarkus.staging</id>
             <url>https://repository.apache.org/content/repositories/orgapachecamel-1370</url>
@@ -393,6 +394,7 @@
                 <enabled>true</enabled>
             </releases>
         </repository>
+        -->
         <repository>
             <id>apache.snapshots</id>
             <url>https://repository.apache.org/snapshots/</url>
@@ -407,6 +409,7 @@
     </repositories>
 
     <pluginRepositories>
+        <!--
         <pluginRepository>
             <id>camel.quarkus.staging</id>
             <url>https://repository.apache.org/content/repositories/orgapachecamel-1370</url>
@@ -418,6 +421,7 @@
                 <enabled>true</enabled>
             </releases>
         </pluginRepository>
+        -->
         <pluginRepository>
             <id>apache.snapshots</id>
             <url>https://repository.apache.org/snapshots/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <maven-resources-plugin-version>3.2.0</maven-resources-plugin-version>
         <maven-site-plugin-version>3.9.1</maven-site-plugin-version>
         <maven-pmd-plugin-version>3.15.0</maven-pmd-plugin-version>
+        <maven-pmd-plugin-asm-version>9.2</maven-pmd-plugin-asm-version>
         <maven-plugin-plugin-version>3.6.1</maven-plugin-plugin-version>
         <maven-version>3.6.3</maven-version>
         <maven-plugin-tools-version>3.6.1</maven-plugin-tools-version>
@@ -1046,6 +1047,13 @@
                                 <excludeRoot>${project.build.directory}/generated-sources</excludeRoot>
                             </excludeRoots>
                         </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.ow2.asm</groupId>
+                                <artifactId>asm</artifactId>
+                                <version>${maven-pmd-plugin-asm-version}</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>3.11.2</version>
+        <version>3.12.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -38,12 +38,12 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <camel-version>3.11.2</camel-version>
+        <camel-version>3.12.0</camel-version>
 
         <!-- quarkus -->
-        <camel-quarkus-version>2.3.0</camel-quarkus-version>
+        <camel-quarkus-version>2.4.0</camel-quarkus-version>
         <graalvm-version>21.2.0</graalvm-version>
-        <quarkus-version>2.3.0.Final</quarkus-version>
+        <quarkus-version>2.4.0.Final</quarkus-version>
 
         <!-- camel-k -->
         <groovy-version>3.0.9</groovy-version>
@@ -382,6 +382,17 @@
 
     <repositories>
         <repository>
+            <id>camel.quarkus.staging</id>
+            <url>https://repository.apache.org/content/repositories/orgapachecamel-1370</url>
+            <name>Apache Snapshot Repo</name>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
             <id>apache.snapshots</id>
             <url>https://repository.apache.org/snapshots/</url>
             <name>Apache Snapshot Repo</name>
@@ -395,6 +406,17 @@
     </repositories>
 
     <pluginRepositories>
+        <pluginRepository>
+            <id>camel.quarkus.staging</id>
+            <url>https://repository.apache.org/content/repositories/orgapachecamel-1370</url>
+            <name>Apache Snapshot Repo</name>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </pluginRepository>
         <pluginRepository>
             <id>apache.snapshots</id>
             <url>https://repository.apache.org/snapshots/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <maven-remote-resources-plugin-version>1.7.0</maven-remote-resources-plugin-version>
         <maven-failsafe-plugin-version>3.0.0-M5</maven-failsafe-plugin-version>
         <versions-maven-plugin-version>2.8.1</versions-maven-plugin-version>
-        <directory-maven-plugin-version>1.0.0</directory-maven-plugin-version>
+        <directory-maven-plugin-version>1.0</directory-maven-plugin-version>
         <exec-maven-plugin-version>3.0.0</exec-maven-plugin-version>
         <mycila-license-version>4.1</mycila-license-version>
         <maven-checkstyle-plugin-version>3.1.2</maven-checkstyle-plugin-version>

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateDependencyListMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateDependencyListMojo.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
@@ -40,7 +41,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.utils.StringUtils;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -93,8 +93,8 @@ public class GenerateDependencyListMojo extends AbstractMojo {
     }
 
     private boolean isCompileOrRuntime(Artifact artifact) {
-        return StringUtils.equals(artifact.getScope(), DefaultArtifact.SCOPE_COMPILE)
-            || StringUtils.equals(artifact.getScope(), DefaultArtifact.SCOPE_RUNTIME);
+        return Objects.equals(artifact.getScope(), DefaultArtifact.SCOPE_COMPILE)
+            || Objects.equals(artifact.getScope(), DefaultArtifact.SCOPE_RUNTIME);
     }
 
     private Map<String, String> artifactToMap(Artifact artifact) {

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateSupport.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateSupport.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.maven.shared.utils.io.IOUtil;
+import org.apache.commons.io.IOUtils;
 
 public final class GenerateSupport {
     private GenerateSupport() {
@@ -32,7 +32,7 @@ public final class GenerateSupport {
                 throw new IllegalStateException("Unable to find catalog-license.txt");
             }
 
-            return IOUtil.toString(is, StandardCharsets.UTF_8.name());
+            return IOUtils.toString(is, StandardCharsets.UTF_8.name());
         }
     }
 }

--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -33,9 +33,12 @@
 
     <properties>
         <camel-version>3.11.0</camel-version>
-        
+
         <!-- reproduceable builds: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
         <project.build.outputTimestamp>1</project.build.outputTimestamp>
+
+        <maven-enforcer-plugin-version>3.0.0</maven-enforcer-plugin-version>
+        <maven-version>3.6.3</maven-version>
     </properties>
 
     <developers>
@@ -222,6 +225,32 @@
         </dependencies>
     </dependencyManagement>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven-enforcer-plugin-version}</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-maven</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireMavenVersion>
+                                        <version>${maven-version}</version>
+                                    </requireMavenVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
     <profiles>
         <profile>
             <id>release</id>


### PR DESCRIPTION
- deps: update to camel-quarkus 2.4.0
- fix: move tests classes to a dedicate package to avoid split package warning
- deps: update directory-maven-plugin to v1.0.0
- deps: update gmavenplus-plugin to v1.13.0
- deps: update maven-pmd-plugin to v3.15.0
- deps: update checkstyle to v8.44
- deps: update directory-maven-plugin to v1.0
- ci: switch to actions/setup-java@v2, use temurin distribution, build on java 17
- deps: force asm version for maven-pmd-plugin
- chore: fix deprecation warnings 

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
