### PR TITLE
chore(deps): move quarkus-logging-json dependency to pom

### DIFF
--- a/camel-k-runtime/deployment/pom.xml
+++ b/camel-k-runtime/deployment/pom.xml
@@ -40,6 +40,10 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-bean-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-json-deployment</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/camel-k-runtime/runtime/pom.xml
+++ b/camel-k-runtime/runtime/pom.xml
@@ -36,6 +36,10 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-bean</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-json</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
@@ -181,7 +181,6 @@ public class GenerateCatalogMojo extends AbstractMojo {
 
             runtimeSpec.applicationClass("io.quarkus.bootstrap.runner.QuarkusEntryPoint");
             runtimeSpec.addDependency("org.apache.camel.k", "camel-k-runtime");
-            runtimeSpec.addDependency("io.quarkus", "quarkus-logging-json");
 
             if (capabilitiesExclusionList != null && !capabilitiesExclusionList.contains("cron")) {
                 runtimeSpec.putCapability(


### PR DESCRIPTION
In order to have a cleaner dependency management, we need to move the declaration of this runtime dependency and have it declared in camel-k-runtime pom.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
