### PR TITLE
remove undertow

### DIFF
--- a/camel-k-loader-jsh/impl/pom.xml
+++ b/camel-k-loader-jsh/impl/pom.xml
@@ -72,11 +72,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-undertow</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
             <artifactId>camel-timer</artifactId>
             <scope>test</scope>
         </dependency>

--- a/itests/camel-k-itests-loader-jsh/src/main/java/org/apache/camel/k/loader/jsh/quarkus/it/JshApplication.java
+++ b/itests/camel-k-itests-loader-jsh/src/main/java/org/apache/camel/k/loader/jsh/quarkus/it/JshApplication.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.k.loader.jsh.quarkus;
+package org.apache.camel.k.loader.jsh.quarkus.it;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;

--- a/itests/camel-k-itests-loader-jsh/src/test/java/org/apache/camel/k/loader/jsh/it/JshLoaderTest.java
+++ b/itests/camel-k-itests-loader-jsh/src/test/java/org/apache/camel/k/loader/jsh/it/JshLoaderTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.k.loader.jsh;
+package org.apache.camel.k.loader.jsh.it;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>3.11.2</version>
+        <version>3.12.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -38,12 +38,12 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <camel-version>3.11.2</camel-version>
+        <camel-version>3.12.0</camel-version>
 
         <!-- quarkus -->
-        <camel-quarkus-version>2.3.0</camel-quarkus-version>
+        <camel-quarkus-version>2.4.0</camel-quarkus-version>
         <graalvm-version>21.2.0</graalvm-version>
-        <quarkus-version>2.3.0.Final</quarkus-version>
+        <quarkus-version>2.4.0.Final</quarkus-version>
 
         <!-- camel-k -->
         <groovy-version>3.0.9</groovy-version>
@@ -382,6 +382,17 @@
 
     <repositories>
         <repository>
+            <id>camel.quarkus.staging</id>
+            <url>https://repository.apache.org/content/repositories/orgapachecamel-1370</url>
+            <name>Apache Snapshot Repo</name>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
             <id>apache.snapshots</id>
             <url>https://repository.apache.org/snapshots/</url>
             <name>Apache Snapshot Repo</name>
@@ -395,6 +406,17 @@
     </repositories>
 
     <pluginRepositories>
+        <pluginRepository>
+            <id>camel.quarkus.staging</id>
+            <url>https://repository.apache.org/content/repositories/orgapachecamel-1370</url>
+            <name>Apache Snapshot Repo</name>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </pluginRepository>
         <pluginRepository>
             <id>apache.snapshots</id>
             <url>https://repository.apache.org/snapshots/</url>


### PR DESCRIPTION
- deps: update to camel-quarkus 2.4.0
- fix: move tests classes to a dedicate package to avoid split package warning
- chore: remove unused undertow depdendency

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
