### PR TITLE
fix(docs): grammar correction in JavaScript docs

### DIFF
--- a/docs/modules/languages/pages/javascript.adoc
+++ b/docs/modules/languages/pages/javascript.adoc
@@ -25,7 +25,7 @@ To run it, you need just to execute:
 kamel run hello.js
 ```
 
-For JavaScript integrations, Camel K does not yet provide an enhanced DSL, but you can access to some global bounded objects such as a writable registry and the camel context so to set the property _exchangeFormatter_ of the _LogComponent_ as done in previous example, you can do something like:
+For JavaScript integrations, Camel K does not yet provide an enhanced DSL, but you can access some global bounded objects such as a writable registry and the camel context so to set the property _exchangeFormatter_ of the _LogComponent_ as done in previous example, you can do something like:
 
 [source,js]
 ----


### PR DESCRIPTION
<!-- Description -->

There was a very slight grammar issue in the docs regarding JavaScript advanced escape hatches, likely b/c of editing/changing sentence structure over time. 


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
