### PR TITLE
camel-website-701 RI update attribute name (main)

### DIFF
--- a/docs/modules/languages/pages/yaml.adoc
+++ b/docs/modules/languages/pages/yaml.adoc
@@ -160,7 +160,7 @@ Support for Endpoint DSL auto completion https://github.com/apache/camel-k-runti
 
 == Defining beans
 
-In addition to the general support for creating beans provided by xref:{camel-version}@components:others:main.adoc#_specifying_custom_beans[Camel Main], the YAML DSL provide a convenient syntax to define and configure them:
+In addition to the general support for creating beans provided by xref:{camel-docs-version}@components:others:main.adoc#_specifying_custom_beans[Camel Main], the YAML DSL provide a convenient syntax to define and configure them:
 
 [source,yaml]
 ----


### PR DESCRIPTION
See apache/camel-website#701
This must be merged at the same time as the corresponding camel-k-runtime PR