### PR TITLE
Camel-dependencies should point to 3.14.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>3.14.0</version>
+        <version>3.14.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
**Release Note**
```release-note
NONE
```
