### PR TITLE
Fix the Camel-K version for the doc generation

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -18,4 +18,4 @@
 # The main part of this distributed component is in camel-k docs
 
 name: camel-k
-version: 1.13.x
+version: 1.9.x


### PR DESCRIPTION
## Motivation

The website build fails with the next error due to some broken links.

```
➤ YN0000: [build:antora  ] [build:antora-perf] [05:59:00.324] WARN (asciidoctor): skipping reference to missing attribute: camel-docs-version
➤ YN0000: [build:antora  ] [build:antora-perf]     file: docs/modules/languages/pages/yaml.adoc
➤ YN0000: [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel-k-runtime.git (refname: release-1.13.x, start path: docs)
➤ YN0000: [build:antora  ] [build:antora-perf] [05:59:00.325] ERROR (asciidoctor): target of xref not found: {camel-docs-version}@components:others:main.adoc#_specifying_custom_beans
➤ YN0000: [build:antora  ] [build:antora-perf]     file: docs/modules/languages/pages/yaml.adoc
➤ YN0000: [build:antora  ] [build:antora-perf]     source: https://github.com/apache/camel-k-runtime.git (refname: release-1.13.x, start path: docs)
```

## Modifications

* Set the expected version of camel-k to ensure that the attribute `camel-docs-version` will be found which will also fix the broken link 