### PR TITLE
Add preliminary support for the Resume API for Camel K

### DIFF
--- a/camel-k-resume-kafka/deployment/pom.xml
+++ b/camel-k-resume-kafka/deployment/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.k</groupId>
+        <artifactId>camel-k-resume-kafka-parent</artifactId>
+        <version>1.14.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-k-resume-kafka-deployment</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-resume-kafka</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus-version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/camel-k-resume-kafka/deployment/src/main/java/org/apache/camel/k/quarkus/resume/deployment/ResumeFeature.java
+++ b/camel-k-resume-kafka/deployment/src/main/java/org/apache/camel/k/quarkus/resume/deployment/ResumeFeature.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.k.quarkus.resume.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+public class ResumeFeature {
+    private static final String FEATURE = "camel-k-resume";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+}

--- a/camel-k-resume-kafka/impl/pom.xml
+++ b/camel-k-resume-kafka/impl/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.k</groupId>
+        <artifactId>camel-k-resume-kafka-parent</artifactId>
+        <version>1.14.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-k-resume-kafka-impl</artifactId>
+
+
+    <dependencies>
+
+        <!-- ****************************** -->
+        <!--                                -->
+        <!-- RUNTIME                        -->
+        <!--                                -->
+        <!-- ****************************** -->
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core-engine</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-core-support</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-apt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- These provide the serializer -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-kafka</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/camel-k-resume-kafka/impl/src/main/java/org/apache/camel/k/resume/ResumeContextCustomizer.java
+++ b/camel-k-resume-kafka/impl/src/main/java/org/apache/camel/k/resume/ResumeContextCustomizer.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.k.resume;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.k.ContextCustomizer;
+import org.apache.camel.k.annotation.Customizer;
+import org.apache.camel.k.resume.kafka.KafkaResumeFactory;
+import org.apache.camel.resume.ResumeStrategy;
+import org.apache.camel.resume.cache.ResumeCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Customizer("resume")
+public class ResumeContextCustomizer implements ContextCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(ResumeContextCustomizer.class);
+    private String resumeStrategy;
+    private String resumeServer;
+    private String resumePath;
+    private String cacheFillPolicy;
+
+
+    @Override
+    public void apply(CamelContext camelContext) {
+        LOG.debug("Receiving context for customization");
+        LOG.debug("Resume strategy: {}", resumeStrategy);
+        LOG.debug("Resume server: {}", resumeServer);
+        LOG.debug("Resume path: {}", resumePath);
+        LOG.debug("Cache fill policy: {}", cacheFillPolicy);
+
+        ResumeCache<?> resumeCache = (ResumeCache<?>) camelContext.getRegistry().lookupByName("cache");
+        LOG.debug("Values from the registry (cache): {}", resumeCache);
+
+        try {
+            ResumeStrategy resumeStrategyInstance = KafkaResumeFactory.build(resumeStrategy, resumeServer, resumePath, cacheFillPolicy);
+
+            LOG.debug("Created resume strategy instance: {}", resumeStrategyInstance.getClass());
+            camelContext.getRegistry().bind("resumeStrategy", resumeStrategyInstance);
+        } catch (Exception e) {
+            LOG.error("Exception: {}", e.getMessage(), e);
+        }
+    }
+
+    public String getResumeStrategy() {
+        return resumeStrategy;
+    }
+
+    public void setResumeStrategy(String resumeStrategy) {
+        this.resumeStrategy = resumeStrategy;
+    }
+
+    public String getResumePath() {
+        return resumePath;
+    }
+
+    public void setResumePath(String resumePath) {
+        this.resumePath = resumePath;
+    }
+
+    public String getResumeServer() {
+        return resumeServer;
+    }
+
+    public void setResumeServer(String resumeServer) {
+        this.resumeServer = resumeServer;
+    }
+
+    public String getCacheFillPolicy() {
+        return cacheFillPolicy;
+    }
+
+    public void setCacheFillPolicy(String cacheFillPolicy) {
+        this.cacheFillPolicy = cacheFillPolicy;
+    }
+}

--- a/camel-k-resume-kafka/impl/src/main/java/org/apache/camel/k/resume/kafka/KafkaResumeFactory.java
+++ b/camel-k-resume-kafka/impl/src/main/java/org/apache/camel/k/resume/kafka/KafkaResumeFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.k.resume.kafka;
+
+import org.apache.camel.processor.resume.kafka.KafkaResumeStrategyConfiguration;
+import org.apache.camel.processor.resume.kafka.KafkaResumeStrategyConfigurationBuilder;
+import org.apache.camel.processor.resume.kafka.MultiNodeKafkaResumeStrategy;
+import org.apache.camel.processor.resume.kafka.SingleNodeKafkaResumeStrategy;
+import org.apache.camel.resume.Cacheable;
+import org.apache.camel.resume.ResumeStrategy;
+import org.apache.camel.util.ObjectHelper;
+
+public final class KafkaResumeFactory {
+
+    private KafkaResumeFactory() {
+
+    }
+
+    public static ResumeStrategy build(String name, String resumeServer, String topic, String cacheFillPolicy) {
+        Cacheable.FillPolicy policy = extracted(cacheFillPolicy);
+
+        final KafkaResumeStrategyConfiguration resumeStrategyConfiguration = KafkaResumeStrategyConfigurationBuilder.newBuilder()
+                .withBootstrapServers(resumeServer)
+                .withCacheFillPolicy(policy)
+                .withTopic(topic)
+                .build();
+
+        switch (name) {
+            case "org.apache.camel.processor.resume.kafka.SingleNodeKafkaResumeStrategy": {
+                return new SingleNodeKafkaResumeStrategy<>(resumeStrategyConfiguration);
+            }
+            case "org.apache.camel.processor.resume.kafka.MultiNodeKafkaResumeStrategy": {
+                return new MultiNodeKafkaResumeStrategy<>(resumeStrategyConfiguration);
+            }
+            default: {
+                throw new UnsupportedOperationException(String.format("The strategy %s is not a valid strategy", name));
+            }
+        }
+    }
+
+    private static Cacheable.FillPolicy extracted(String cacheFillPolicy) {
+        if (!ObjectHelper.isEmpty(cacheFillPolicy) && cacheFillPolicy.equals("minimizing")) {
+            return Cacheable.FillPolicy.MINIMIZING;
+        }
+
+        return Cacheable.FillPolicy.MAXIMIZING;
+    }
+}

--- a/camel-k-resume-kafka/pom.xml
+++ b/camel-k-resume-kafka/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.k</groupId>
+        <artifactId>camel-k-runtime-project</artifactId>
+        <version>1.14.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+
+    <artifactId>camel-k-resume-kafka-parent</artifactId>
+
+    <modules>
+        <module>impl</module>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+
+</project>

--- a/camel-k-resume-kafka/runtime/pom.xml
+++ b/camel-k-resume-kafka/runtime/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.k</groupId>
+        <artifactId>camel-k-resume-kafka-parent</artifactId>
+        <version>1.14.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-k-resume-kafka</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-resume-kafka-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <version>${quarkus-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus-version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -376,10 +376,12 @@
         <module>camel-k-master</module>
         <module>camel-k-webhook</module>
         <module>camel-k-runtime</module>
+        <module>camel-k-resume-kafka</module>
 
         <module>itests</module>
         <module>examples</module>
         <module>distribution</module>
+
     </modules>
 
     <dependencyManagement>

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
@@ -240,6 +240,19 @@ public class GenerateCatalogMojo extends AbstractMojo {
                         .build()
                 );
             }
+            if (capabilitiesExclusionList != null && !capabilitiesExclusionList.contains("resume-kafka")) {
+                runtimeSpec.putCapability(
+                        "resume-kafka",
+                        CamelCapability.forArtifact(
+                                "org.apache.camel.k", "camel-k-resume-kafka"));
+
+                catalogSpec.putArtifact(
+                        new CamelArtifact.Builder()
+                                .groupId("org.apache.camel.k")
+                                .artifactId("camel-k-resume-kafka")
+                                .build()
+                );
+            }
 
             catalogSpec.runtime(runtimeSpec.build());
 

--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -204,6 +204,16 @@
                 <artifactId>camel-k-maven-plugin</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-resume-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-resume</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This includes a new customizer that handles setting up part of the
resume API in the context.


<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```