### PR TITLE
feat: remove template and error handler source types

### DIFF
--- a/camel-k-core/api/src/main/java/org/apache/camel/k/Source.java
+++ b/camel-k-core/api/src/main/java/org/apache/camel/k/Source.java
@@ -31,9 +31,13 @@ public interface Source extends HasId {
     String getLocation();
     String getName();
     String getLanguage();
+
+    @Deprecated
     SourceType getType();
     Optional<String> getLoader();
     List<String> getInterceptors();
+
+    @Deprecated
     List<String> getPropertyNames();
     InputStream resolveAsInputStream(CamelContext ctx);
 

--- a/camel-k-core/api/src/main/java/org/apache/camel/k/SourceDefinition.java
+++ b/camel-k-core/api/src/main/java/org/apache/camel/k/SourceDefinition.java
@@ -92,6 +92,7 @@ public class SourceDefinition implements IdAware {
         this.interceptors = interceptors;
     }
 
+    @Deprecated
     public SourceType getType() {
         return type;
     }
@@ -99,10 +100,12 @@ public class SourceDefinition implements IdAware {
     /**
      * The {@link SourceType} of the source.
      */
+    @Deprecated
     public void setType(SourceType type) {
         this.type = type;
     }
 
+    @Deprecated
     public List<String> getPropertyNames() {
         return propertyNames;
     }
@@ -110,6 +113,7 @@ public class SourceDefinition implements IdAware {
     /**
      * The list of properties names the source requires (used only for templates).
      */
+    @Deprecated
     public void setPropertyNames(List<String> propertyNames) {
         this.propertyNames = propertyNames;
     }

--- a/camel-k-core/support/src/main/java/org/apache/camel/k/support/RuntimeSupport.java
+++ b/camel-k-core/support/src/main/java/org/apache/camel/k/support/RuntimeSupport.java
@@ -44,6 +44,8 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.ExtendedCamelContext;
 import org.apache.camel.builder.RouteBuilderLifecycleStrategy;
 import org.apache.camel.k.ContextCustomizer;
+import org.apache.camel.k.Runtime;
+import org.apache.camel.k.RuntimeAware;
 import org.apache.camel.k.Source;
 import org.apache.camel.spi.HasCamelContext;
 import org.apache.camel.util.IOHelper;
@@ -177,8 +179,8 @@ public final class RuntimeSupport {
     //
     // *********************************
 
-    public static List<RouteBuilderLifecycleStrategy> loadInterceptors(CamelContext context, Source source) {
-        ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
+    public static List<RouteBuilderLifecycleStrategy> loadInterceptors(Runtime runtime, Source source) {
+        ExtendedCamelContext ecc = runtime.getCamelContext().adapt(ExtendedCamelContext.class);
         List<RouteBuilderLifecycleStrategy> answer = new ArrayList<>();
 
         for (String id : source.getInterceptors()) {
@@ -198,8 +200,12 @@ public final class RuntimeSupport {
                     LOGGER.debug("Found source loader interceptor {} from registry", id);
                 }
 
-                PropertiesSupport.bindProperties(context, interceptor, Constants.LOADER_INTERCEPTOR_PREFIX + id + ".");
-                PropertiesSupport.bindProperties(context, interceptor, Constants.LOADER_INTERCEPTOR_PREFIX_FALLBACK + id + ".");
+                PropertiesSupport.bindProperties(ecc, interceptor, Constants.LOADER_INTERCEPTOR_PREFIX + id + ".");
+                PropertiesSupport.bindProperties(ecc, interceptor, Constants.LOADER_INTERCEPTOR_PREFIX_FALLBACK + id + ".");
+
+                if (interceptor instanceof RuntimeAware) {
+                    ((RuntimeAware) interceptor).setRuntime(runtime);
+                }
 
                 answer.add(interceptor);
             } catch (Exception e) {

--- a/itests/camel-k-itests-kamelet/src/test/resources/routes.properties
+++ b/itests/camel-k-itests-kamelet/src/test/resources/routes.properties
@@ -20,11 +20,7 @@
 # camel-k - sources (templates)
 #
 camel.k.sources[0].location          = file:{{env:ROUTES_DIR}}/set-body.yaml
-camel.k.sources[0].type              = template
-camel.k.sources[0].property-names[0] = bodyValue
 camel.k.sources[1].location          = file:{{env:ROUTES_DIR}}/to-upper.yaml
-camel.k.sources[1].type              = template
-camel.k.sources[1].property-names[0] = message
 
 #
 # camel-k - sources (routes)

--- a/itests/camel-k-itests-kamelet/src/test/resources/routes/set-body.yaml
+++ b/itests/camel-k-itests-kamelet/src/test/resources/routes/set-body.yaml
@@ -15,8 +15,12 @@
 # limitations under the License.
 #
 
-- from:
-    uri: "kamelet:source"
-    steps:
-      - set-body:
-          constant: "{{bodyValue}}"
+- template:
+    id: "set-body"
+    parameters:
+      - name: "bodyValue"
+    from:
+      uri: "kamelet:source"
+      steps:
+        - set-body:
+            constant: "{{bodyValue}}"

--- a/itests/camel-k-itests-kamelet/src/test/resources/routes/to-upper.yaml
+++ b/itests/camel-k-itests-kamelet/src/test/resources/routes/to-upper.yaml
@@ -15,10 +15,14 @@
 # limitations under the License.
 #
 
-- from:
-    uri: "kamelet:source"
-    steps:
-      - set-body:
-          constant: "{{message}}"
-      - set-body:
-          simple: "${in.body.toUpperCase()}"
+- template:
+    id: "to-upper"
+    parameters:
+      - name: "message"
+    from:
+      uri: "kamelet:source"
+      steps:
+        - set-body:
+            constant: "{{message}}"
+        - set-body:
+            simple: "${in.body.toUpperCase()}"


### PR DESCRIPTION
<!-- Description -->

This PR is aimed to explore what we can remove from the camel-k runtime in order to ease the migration of the remaining code in this repo to camel-quarkus and in particular I'm focused on removing the specific source types we have introduced in camel-k long ago.

1. templates: all the DSLs now have support for routes templates so it is not more needed to have a wrapper that can turn a standard route in a template
2. error handler: the YAML DSL has now native support for global error handler and as we are using this errror handler source type exclusively to support kamelet bindings, then I think, we can remove the custom source type and use what is provided by the YAML DSL

There is still an issue that is related to the order on which routes are loaded but this can be explored on the apache camel side.

@squakez @davsclaus what do you think ?


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
