### PR TITLE
bump maven-pmd-plugin 3.18.0 and cleanup camel-k-maven-plugin deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,9 @@
         <maven-enforcer-plugin-version>3.1.0</maven-enforcer-plugin-version>
         <maven-resources-plugin-version>3.3.0</maven-resources-plugin-version>
         <maven-site-plugin-version>3.12.1</maven-site-plugin-version>
-        <maven-pmd-plugin-version>3.17.0</maven-pmd-plugin-version>
+        <maven-pmd-plugin-version>3.18.0</maven-pmd-plugin-version>
         <maven-pmd-plugin-asm-version>9.3</maven-pmd-plugin-asm-version>
+        <maven-pmd-plugin-shared-utils-version>3.3.3</maven-pmd-plugin-shared-utils-version>
         <maven-plugin-plugin-version>3.6.4</maven-plugin-plugin-version>
         <maven-version>3.6.3</maven-version>
         <maven-plugin-tools-version>3.6.4</maven-plugin-tools-version>
@@ -925,6 +926,11 @@
                                 <groupId>org.ow2.asm</groupId>
                                 <artifactId>asm</artifactId>
                                 <version>${maven-pmd-plugin-asm-version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.maven.shared</groupId>
+                                <artifactId>maven-shared-utils</artifactId>
+                                <version>${maven-pmd-plugin-shared-utils-version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/support/camel-k-maven-plugin/pom.xml
+++ b/support/camel-k-maven-plugin/pom.xml
@@ -43,36 +43,17 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.plexus</groupId>
-                    <artifactId>plexus-utils</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-common-artifact-filters</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.maven</groupId>
-                    <artifactId>maven-repository-metadata</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.plexus</groupId>
-                    <artifactId>plexus-utils</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -105,6 +86,10 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- build(deps): bump maven-pmd-plugin from 3.17.0 to 3.18.0
- chore: cleanup camel-k-maven-plugin dependencies

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
