### PR TITLE
Set jolokia dependency in camel-k-runtime-bom to avoid declaring the dependency in camel-k

### DIFF
--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <!-- reproduceable builds: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
         <project.build.outputTimestamp>1664443789</project.build.outputTimestamp>
-
+        <jolokia-version>1.7.1</jolokia-version>
         <maven-enforcer-plugin-version>3.1.0</maven-enforcer-plugin-version>
         <maven-version>3.6.3</maven-version>
         <quarkus-platform-version>2.13.0.Final</quarkus-platform-version>
@@ -214,6 +214,11 @@
                 <groupId>org.apache.camel.k</groupId>
                 <artifactId>camel-k-resume-kafka</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jolokia</groupId>
+                <artifactId>jolokia-jvm</artifactId>
+                <version>${jolokia-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The jolokia trait [sets the dependency and version in jolokia.go](https://github.com/apache/camel-k/blob/v1.10.1/pkg/trait/jolokia.go#L66). We should avoid declaring the version there and let camel-k-runtime-bom manage the dependencies.

**Release Note**
```release-note
NONE
```
