### PR TITLE
Use slf4j 2.0.1 as this is the compatible version for logback 1.4.1

### DIFF
--- a/support/camel-k-maven-logging/pom.xml
+++ b/support/camel-k-maven-logging/pom.xml
@@ -30,6 +30,7 @@
 
     <properties>
       <!-- Maven structural logging -->
+      <slf4j-version>2.0.1</slf4j-version>
       <logback-version>1.4.1</logback-version>
       <logstash-logback-version>7.2</logstash-logback-version>
       <jackson-version>2.13.4</jackson-version>
@@ -67,6 +68,11 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -141,6 +147,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
https://logback.qos.ch/news.html
https://www.slf4j.org/codes.html#StaticLoggerBinder

Using logback 1.4.1 with slf4j 1.7.x (default in maven 3.8.3) prints
```
SLF4J: Failed to load class \"org.slf4j.impl.StaticLoggerBinder
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details
```
Any integration build in Camel K fails

**Release Note**
```release-note
NONE
```
