### PR TITLE
Revert logback uprgade to 1.2.11

### DIFF
--- a/support/camel-k-maven-logging/pom.xml
+++ b/support/camel-k-maven-logging/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
       <!-- Maven structural logging -->
-      <logback-version>1.4.1</logback-version>
+      <logback-version>1.2.11</logback-version>
       <logstash-logback-version>7.2</logstash-logback-version>
       <jackson-version>2.13.4</jackson-version>
     </properties>


### PR DESCRIPTION
logback 1.4.1 requires slf4j 2.0.1, which requires additional changes in maven library when used in camel-k to build integrations Read more info from the closed PR https://github.com/apache/camel-k-runtime/pull/902

**Release Note**
```release-note
NONE
```
