### PR TITLE
chore: dependency cleaning

### DIFF
--- a/camel-k-core/support/pom.xml
+++ b/camel-k-core/support/pom.xml
@@ -67,12 +67,6 @@
             <artifactId>camel-k-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j-version}</version>
-            <scope>test</scope>
-        </dependency>
 
     </dependencies>
 

--- a/itests/camel-k-itests-cron/pom.xml
+++ b/itests/camel-k-itests-cron/pom.xml
@@ -87,7 +87,6 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>${awaitility-version}</version>
         </dependency>
 
         <!-- The following dependencies guarantee that this module is built after them.  -->

--- a/itests/camel-k-itests-webhook/pom.xml
+++ b/itests/camel-k-itests-webhook/pom.xml
@@ -99,7 +99,6 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>${awaitility-version}</version>
         </dependency>
 
         <!-- The following dependencies guarantee that this module is built after them.  -->

--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,6 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <parent>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-dependencies</artifactId>
-        <version>3.18.0</version>
-    </parent>
-
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.k</groupId>
     <artifactId>camel-k-runtime-project</artifactId>
@@ -46,9 +40,12 @@
         <quarkus-platform-version>2.13.0.Final</quarkus-platform-version>
         <quarkus-native-builder-image>quay.io/quarkus/ubi-quarkus-native-image:22.1.0-java11</quarkus-native-builder-image>
 
-        <!-- camel-k -->
+        <!-- camel-k-runtime specific -->
         <groovy-version>3.0.13</groovy-version>
         <immutables-version>2.9.2</immutables-version>
+        <commons-collections4-version>4.4</commons-collections4-version>
+        <assertj-version>3.23.1</assertj-version>
+        <hamcrest-version>2.2</hamcrest-version>
 
         <!-- plugins -->
         <gmavenplus-plugin-version>1.13.1</gmavenplus-plugin-version>
@@ -203,13 +200,6 @@
                     <groupId>org.jboss.jandex</groupId>
                     <artifactId>jandex-maven-plugin</artifactId>
                     <version>${jandex-maven-plugin-version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.jboss</groupId>
-                            <artifactId>jandex</artifactId>
-                            <version>${jandex-version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -263,25 +253,11 @@
                     <groupId>org.apache.camel</groupId>
                     <artifactId>camel-component-maven-plugin</artifactId>
                     <version>${camel-version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.jboss</groupId>
-                            <artifactId>jandex</artifactId>
-                            <version>${jandex-version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.camel</groupId>
                     <artifactId>camel-package-maven-plugin</artifactId>
                     <version>${camel-version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.jboss</groupId>
-                            <artifactId>jandex</artifactId>
-                            <version>${jandex-version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.gmavenplus</groupId>
@@ -291,7 +267,6 @@
                 <plugin>
                     <groupId>org.jetbrains.kotlin</groupId>
                     <artifactId>kotlin-maven-plugin</artifactId>
-                    <version>${kotlin-version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -388,25 +363,11 @@
     </modules>
 
     <dependencyManagement>
-        <dependencies>
+        <dependencies>     
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-bom</artifactId>
                 <version>${camel-version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson2-version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-bom</artifactId>
-                <version>${kotlin-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -637,34 +598,9 @@
 
             <!-- misc -->
             <dependency>
-                <groupId>io.rest-assured</groupId>
-                <artifactId>rest-assured</artifactId>
-                <version>${rest-assured-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.awaitility</groupId>
-                <artifactId>awaitility</artifactId>
-                <version>${awaitility-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>${snakeyaml-version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.immutables</groupId>
                 <artifactId>value</artifactId>
                 <version>${immutables-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss</groupId>
-                <artifactId>jandex</artifactId>
-                <version>${jandex-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter</artifactId>
-                <version>${junit-jupiter-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
@@ -675,11 +611,6 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
                 <version>${hamcrest-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-ext-jdk18on</artifactId>
-                <version>${bouncycastle-version}</version>
             </dependency>
 
             <!-- maven -->


### PR DESCRIPTION
<!-- Description -->
With this PR we provide a bit of dependency cleaning, removing 2 BOMs that are no longer needed and above all, removing the inheritance from `camel-depencencies` that was an headache when bumping camel version (we had to remind to keep aligned in 2 different places).

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore: dependency cleaning
```
