### PR TITLE
fix(deps): brought back inheritance to camel deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,12 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+    <parent>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-dependencies</artifactId>
+        <version>3.18.0</version>
+    </parent>
+
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.k</groupId>
     <artifactId>camel-k-runtime-project</artifactId>
@@ -130,7 +136,7 @@
                           <rules>
                             <requireMavenVersion>
                               <version>${maven-version}</version>
-                            </requireMavenVersion>
+                            </requireMavenVersion>                           
                           </rules>
                         </configuration>
                       </execution>
@@ -291,6 +297,30 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven-enforcer-plugin-version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                    <id>enforce-camel-version</id>
+                    <goals>
+                        <goal>enforce</goal>
+                    </goals>
+                    <configuration>
+                        <rules>
+                            <requireProperty>
+                                <property>camel-version</property>
+                                <regex>${project.parent.version}</regex>
+                                <regexMessage>Camel version must be equals to camel-dependency parent pom version (${project.parent.version})!</regexMessage>
+                            </requireProperty>                            
+                        </rules>
+                        <fail>true</fail>
+                    </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-remote-resources-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>3.18.0</version>
+        <version>3.18.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -36,6 +36,7 @@ main() {
   fi
 
   if [[ ! -z "$CAMEL" ]]; then
+    mvn versions:update-parent "-DparentVersion=[$CAMEL]" -DgenerateBackupPoms=false
     mvn versions:set-property -Dproperty="camel-version" -DnewVersion="$CAMEL" -DgenerateBackupPoms=false
     echo "Camel version set to $CAMEL"
   fi


### PR DESCRIPTION
Closes #918

<!-- Description -->

We need to bring back the inheritance to the `camel-dependencies` pom as that contains information for the release. However, I've added an enforcer rule to make sure the `camel-version` is aligned with the `camel-dependencies` version. The first commit of this PR should fail to prove the rule is fine.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(deps): brought back inheritance to camel deps
```
