### PR TITLE
1.16.0 prepare

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>3.18.3</version>
+        <version>3.19.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -38,7 +38,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <camel-version>3.18.3</camel-version>
+        <camel-version>3.19.0</camel-version>
 
         <!-- quarkus -->
         <camel-quarkus-version>2.13.1</camel-quarkus-version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <!-- quarkus -->
         <camel-quarkus-version>2.14.0</camel-quarkus-version>
         <quarkus-version>2.14.0.Final</quarkus-version>
-        <quarkus-platform-version>2.13.4.Final</quarkus-platform-version>
+        <quarkus-platform-version>2.14.0.Final</quarkus-platform-version>
         <quarkus-native-builder-image>quay.io/quarkus/ubi-quarkus-native-image:22.3.0-java11</quarkus-native-builder-image>
 
         <!-- camel-k-runtime specific -->

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
         <!-- quarkus -->
         <camel-quarkus-version>2.14.0</camel-quarkus-version>
-        <quarkus-version>2.13.3.Final</quarkus-version>
+        <quarkus-version>2.14.0.Final</quarkus-version>
         <quarkus-platform-version>2.13.4.Final</quarkus-platform-version>
         <quarkus-native-builder-image>quay.io/quarkus/ubi-quarkus-native-image:22.3.0-java11</quarkus-native-builder-image>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <camel-version>3.19.0</camel-version>
 
         <!-- quarkus -->
-        <camel-quarkus-version>2.13.1</camel-quarkus-version>
+        <camel-quarkus-version>2.14.0</camel-quarkus-version>
         <quarkus-version>2.13.3.Final</quarkus-version>
         <quarkus-platform-version>2.13.4.Final</quarkus-platform-version>
         <quarkus-native-builder-image>quay.io/quarkus/ubi-quarkus-native-image:22.3.0-java11</quarkus-native-builder-image>

--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -38,7 +38,7 @@
         <jolokia-version>1.7.1</jolokia-version>
         <maven-enforcer-plugin-version>3.1.0</maven-enforcer-plugin-version>
         <maven-version>3.6.3</maven-version>
-        <quarkus-platform-version>2.13.4.Final</quarkus-platform-version>
+        <quarkus-platform-version>2.14.0.Final</quarkus-platform-version>
     </properties>
 
     <developers>


### PR DESCRIPTION
**Release Note**
```release-note
Aligning to Camel 3.19.0, Quarkus 2.14.0.Final, Quarkus Platform 2.14.0.Final and Camel-quarkus 2.14.0
```
All set, there is one single error in catalog. We have duplicate schemes for knative

```
[INFO] Running post-build script: /home/oscerd/workspace/apache-camel/camel-k-runtime/support/camel-k-maven-plugin/target/it/generate-catalog/verify.groovy
[INFO]   The post-build script did not succeed. Duplicated schemes: [knative]. Expression: (diff.size() == 0)
[INFO]           generate-catalog/pom.xml ......................... FAILED (3.0 s)
```

