### PR TITLE
fix(ci): keep version artifact only

### DIFF
--- a/distribution/src/main/assemblies/repository.xml
+++ b/distribution/src/main/assemblies/repository.xml
@@ -29,8 +29,11 @@
       <outputDirectory>./</outputDirectory>
       <directory>${settings.localRepository}</directory>
       <includes>
-        <include>org/apache/camel/k/**</include>
+        <include>org/apache/camel/k/*/${project.version}/**</include>
       </includes>
+      <excludes>
+        <exclude>org/apache/camel/k/apache-camel-k-runtime/**</exclude>
+      </excludes>
      </fileSet>
   </fileSets>
 </assembly>


### PR DESCRIPTION
<!-- Description -->
With this PR we only include the artifacts related to the actual version. The issue was creating huge distribution artifact containing also previous version of the project (ie, https://repo1.maven.org/maven2/org/apache/camel/k/apache-camel-k-runtime/1.15.0/apache-camel-k-runtime-1.15.0-m2.zip is 1.7 GB!)

Ref https://github.com/apache/camel-k/issues/3826

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(ci): keep version artifact only
```
