### PR TITLE
Set knative as a know http endpoint

### DIFF
--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
@@ -79,6 +79,7 @@ public class GenerateCatalogMojo extends AbstractMojo {
         "cxfrs",
         "grpc",
         "jetty",
+        "knative",
         "netty-http",
         "platform-http",
         "rest",


### PR DESCRIPTION
https://github.com/apache/camel-k-runtime/pull/927 removed the knative setting as a know http endpoint, we should re-add it.

**Release Note**
```release-note
NONE
```
