### PR TITLE
feat(catalog): publish Mandrel image info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <quarkus-platform-version>2.14.0.Final</quarkus-platform-version>
         <!-- The quarkus camel bom may differ from quarkus platfom -->
         <quarkus-camel-bom-version>2.14.0.Final</quarkus-camel-bom-version>
-        <quarkus-native-builder-image>quay.io/quarkus/ubi-quarkus-native-image:22.3.0-java11</quarkus-native-builder-image>
+        <quarkus-native-builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3.3.0-Final-java11</quarkus-native-builder-image>
 
         <!-- camel-k-runtime specific -->
         <groovy-version>3.0.13</groovy-version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <quarkus-platform-version>2.14.0.Final</quarkus-platform-version>
         <!-- The quarkus camel bom may differ from quarkus platfom -->
         <quarkus-camel-bom-version>2.14.0.Final</quarkus-camel-bom-version>
-        <quarkus-native-builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3.3.0-Final-java11</quarkus-native-builder-image>
+        <quarkus-native-builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.2.0.0-Final-java11</quarkus-native-builder-image>
 
         <!-- camel-k-runtime specific -->
         <groovy-version>3.0.13</groovy-version>

--- a/support/camel-k-maven-plugin/pom.xml
+++ b/support/camel-k-maven-plugin/pom.xml
@@ -123,6 +123,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -167,6 +173,7 @@
                         <camelVersion>${camel-version}</camelVersion>
                         <camelQuarkusVersion>${camel-quarkus-version}</camelQuarkusVersion>
                         <quarkusVersion>${quarkus-version}</quarkusVersion>
+                        <quarkusNativeBuilderImage>${quarkus-native-builder-image}</quarkusNativeBuilderImage>
                     </scriptVariables>
                     <pomIncludes>
                         <pomInclude>generate-catalog/pom.xml</pomInclude>

--- a/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
@@ -24,6 +24,7 @@ new File(basedir, "catalog.yaml").withReader {
     // Re-enabled this when the version will be the same again
     //assert catalog.spec.runtime.metadata['quarkus.version'] == quarkusVersion
     assert catalog.spec.runtime.metadata['camel-quarkus.version'] == camelQuarkusVersion
+    assert catalog.spec.runtime.metadata['quarkus.native-builder-image'] == quarkusNativeBuilderImage
 
     assert catalog.spec.runtime.dependencies.any {
         it.groupId == 'org.apache.camel.k' && it.artifactId == 'camel-k-runtime'

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
@@ -179,6 +179,8 @@ public class GenerateCatalogMojo extends AbstractMojo {
                 "org.apache.camel.quarkus", "camel-quarkus-catalog",
                 version -> runtimeSpec.putMetadata("camel-quarkus.version", version));
 
+            runtimeSpec.putMetadata("quarkus.native-builder-image", MavenSupport.getApplicationProperty(getClass(), "quarkus.native-builder-image"));
+
             runtimeSpec.applicationClass("io.quarkus.bootstrap.runner.QuarkusEntryPoint");
             runtimeSpec.addDependency("org.apache.camel.k", "camel-k-runtime");
 

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/support/MavenSupport.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/support/MavenSupport.java
@@ -27,6 +27,16 @@ public final class MavenSupport {
     private MavenSupport() {
     }
 
+    public static String getApplicationProperty(Class<?> clazz, String property){
+        try (InputStream is = clazz.getResourceAsStream("/app.properties")) {
+            Properties p = new Properties();
+            p.load(is);
+            return p.getProperty( property );
+        } catch (Exception ignored) {
+        }
+        return "";
+    }
+
     public static String getVersion(Class<?> clazz, String path) {
         String version = null;
 

--- a/support/camel-k-maven-plugin/src/main/resources/app.properties
+++ b/support/camel-k-maven-plugin/src/main/resources/app.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+quarkus.native-builder-image=${quarkus-native-builder-image}


### PR DESCRIPTION
This PR will publish the Quarkus native image builder into the catalog, enabling the possibility to dynamically use it on Camel K (a step towards decoupling).

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(catalog): publish Mandrel image info
```
