### PR TITLE
feat(catalog) : Add telemetry capability

### DIFF
--- a/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
@@ -42,6 +42,8 @@ new File(basedir, "catalog.yaml").withReader {
     assert catalog.spec.runtime.capabilities['circuit-breaker'].dependencies[0].artifactId == 'camel-quarkus-microprofile-fault-tolerance'
     assert catalog.spec.runtime.capabilities['tracing'].dependencies[0].groupId == 'org.apache.camel.quarkus'
     assert catalog.spec.runtime.capabilities['tracing'].dependencies[0].artifactId == 'camel-quarkus-opentracing'
+    assert catalog.spec.runtime.capabilities['telemetry'].dependencies[0].groupId == 'org.apache.camel.quarkus'
+    assert catalog.spec.runtime.capabilities['telemetry'].dependencies[0].artifactId == 'camel-quarkus-opentelemetry'
     assert catalog.spec.runtime.capabilities['master'].dependencies[0].groupId == 'org.apache.camel.k'
     assert catalog.spec.runtime.capabilities['master'].dependencies[0].artifactId == 'camel-k-master'
 

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
@@ -229,6 +229,12 @@ public class GenerateCatalogMojo extends AbstractMojo {
                     CamelCapability.forArtifact(
                         "org.apache.camel.quarkus", "camel-quarkus-opentracing"));
             }
+            if (capabilitiesExclusionList != null && !capabilitiesExclusionList.contains("telemetry")) {
+                runtimeSpec.putCapability(
+                        "telemetry",
+                        CamelCapability.forArtifact(
+                                "org.apache.camel.quarkus", "camel-quarkus-opentelemetry"));
+            }
             if (capabilitiesExclusionList != null && !capabilitiesExclusionList.contains("master")) {
                 runtimeSpec.putCapability(
                     "master",


### PR DESCRIPTION
Uses camel-quarkus opentelemetry extension for new telemetry capability in catalog

resolves #apache/camel-k#3519

**Release Note**
```release-note
feat(catalog): Add telemetry capability
```
