### PR TITLE
Ref #953: Update DSLs metadata

### DIFF
--- a/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
@@ -47,6 +47,42 @@ new File(basedir, "catalog.yaml").withReader {
     assert catalog.spec.runtime.capabilities['master'].dependencies[0].groupId == 'org.apache.camel.k'
     assert catalog.spec.runtime.capabilities['master'].dependencies[0].artifactId == 'camel-k-master'
 
+    assert catalog.spec.loaders['groovy'].groupId == 'org.apache.camel.quarkus'
+    assert catalog.spec.loaders['groovy'].artifactId == 'camel-quarkus-groovy-dsl'
+    assert catalog.spec.loaders['groovy'].languages[0] == 'groovy'
+    assert catalog.spec.loaders['groovy'].metadata['native'] == 'true'
+    assert catalog.spec.loaders['groovy'].metadata['sources-required-at-build-time'] == 'true'
+    assert catalog.spec.loaders['java'].groupId == 'org.apache.camel.quarkus'
+    assert catalog.spec.loaders['java'].artifactId == 'camel-quarkus-java-joor-dsl'
+    assert catalog.spec.loaders['java'].languages[0] == 'java'
+    assert catalog.spec.loaders['java'].metadata['native'] == 'true'
+    assert catalog.spec.loaders['java'].metadata['sources-required-at-build-time'] == 'true'
+    assert catalog.spec.loaders['jsh'].groupId == 'org.apache.camel.quarkus'
+    assert catalog.spec.loaders['jsh'].artifactId == 'camel-quarkus-jsh-dsl'
+    assert catalog.spec.loaders['jsh'].languages[0] == 'jsh'
+    assert catalog.spec.loaders['jsh'].metadata['native'] == 'false'
+    assert catalog.spec.loaders['jsh'].metadata['sources-required-at-build-time'] == 'true'
+    assert catalog.spec.loaders['kts'].groupId == 'org.apache.camel.quarkus'
+    assert catalog.spec.loaders['kts'].artifactId == 'camel-quarkus-kotlin-dsl'
+    assert catalog.spec.loaders['kts'].languages[0] == 'kts'
+    assert catalog.spec.loaders['kts'].metadata['native'] == 'true'
+    assert catalog.spec.loaders['kts'].metadata['sources-required-at-build-time'] == 'true'
+    assert catalog.spec.loaders['js'].groupId == 'org.apache.camel.quarkus'
+    assert catalog.spec.loaders['js'].artifactId == 'camel-quarkus-js-dsl'
+    assert catalog.spec.loaders['js'].languages[0] == 'js'
+    assert catalog.spec.loaders['js'].metadata['native'] == 'false'
+    assert catalog.spec.loaders['js'].metadata['sources-required-at-build-time'] == null
+    assert catalog.spec.loaders['xml'].groupId == 'org.apache.camel.quarkus'
+    assert catalog.spec.loaders['xml'].artifactId == 'camel-quarkus-xml-io-dsl'
+    assert catalog.spec.loaders['xml'].languages[0] == 'xml'
+    assert catalog.spec.loaders['xml'].metadata['native'] == 'true'
+    assert catalog.spec.loaders['xml'].metadata['sources-required-at-build-time'] == null
+    assert catalog.spec.loaders['yaml'].groupId == 'org.apache.camel.quarkus'
+    assert catalog.spec.loaders['yaml'].artifactId == 'camel-quarkus-yaml-dsl'
+    assert catalog.spec.loaders['yaml'].languages[0] == 'yaml'
+    assert catalog.spec.loaders['yaml'].metadata['native'] == 'true'
+    assert catalog.spec.loaders['yaml'].metadata['sources-required-at-build-time'] == null
+
     assert catalog.metadata.labels['camel.apache.org/runtime.version'] == runtimeVersion
 
     catalog.spec.artifacts['camel-k-master'].with {

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
@@ -358,7 +358,8 @@ public class GenerateCatalogMojo extends AbstractMojo {
                 "groovy",
                 CamelLoader.fromArtifact("org.apache.camel.quarkus", "camel-quarkus-groovy-dsl")
                     .addLanguage("groovy")
-                    .putMetadata("native", "false")
+                    .putMetadata("native", "true")
+                    .putMetadata("sources-required-at-build-time", "true")
                     .build()
             );
         }
@@ -367,7 +368,8 @@ public class GenerateCatalogMojo extends AbstractMojo {
                 "kts",
                 CamelLoader.fromArtifact("org.apache.camel.quarkus", "camel-quarkus-kotlin-dsl")
                     .addLanguage("kts")
-                    .putMetadata("native", "false")
+                    .putMetadata("native", "true")
+                    .putMetadata("sources-required-at-build-time", "true")
                     .build()
             );
         }
@@ -376,7 +378,8 @@ public class GenerateCatalogMojo extends AbstractMojo {
                 "js",
                 CamelLoader.fromArtifact("org.apache.camel.quarkus", "camel-quarkus-js-dsl")
                     .addLanguage("js")
-                    .putMetadata("native", "true")
+                    // Guest languages are not yet supported on Mandrel in native mode.
+                    .putMetadata("native", "false")
                     .build()
             );
         }
@@ -394,7 +397,19 @@ public class GenerateCatalogMojo extends AbstractMojo {
                 "java",
                 CamelLoader.fromArtifact("org.apache.camel.quarkus", "camel-quarkus-java-joor-dsl")
                     .addLanguages("java")
+                    .putMetadata("native", "true")
+                    .putMetadata("sources-required-at-build-time", "true")
+                    .build()
+            );
+        }
+        if (dslsExclusionList != null && !dslsExclusionList.contains("jsh")) {
+            specBuilder.putLoader(
+                "jsh",
+                CamelLoader.fromArtifact("org.apache.camel.quarkus", "camel-quarkus-jsh-dsl")
+                    .addLanguages("jsh")
+                    // Native mode is not yet supported due to https://github.com/apache/camel-quarkus/issues/4458.
                     .putMetadata("native", "false")
+                    .putMetadata("sources-required-at-build-time", "true")
                     .build()
             );
         }


### PR DESCRIPTION
fixes #953 

## Motivation

In Camel-Quarkus 2.16.0 several DSLs have been improved to support the native mode, the metadata needs to be updated consequently.

## Modifications:

* Switch the metadata `native` to `true` for the DSLs `groovy`, `kotlin`, and `java-joor` 
* Add the DSL `jsh`
* Set the metadata `sources-required-at-build-time` to `true` when needed to indicate that the sources need to be present while building the native image.
* Set the metadata `native` to `false` for the JavaScript DSL since it is not supported on Mandrel

**Release Note**
```release-note
Update DSLs metadata
```
