### PR TITLE
feat: version aligned to Apache Camel

### DIFF
--- a/camel-k-cloudevents/deployment/pom.xml
+++ b/camel-k-cloudevents/deployment/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-cloudevents-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-cloudevents/pom.xml
+++ b/camel-k-cloudevents/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-project</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/camel-k-cloudevents/runtime/pom.xml
+++ b/camel-k-cloudevents/runtime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-cloudevents-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-core/api/pom.xml
+++ b/camel-k-core/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-core-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-core/deployment/pom.xml
+++ b/camel-k-core/deployment/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-core-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-core/pom.xml
+++ b/camel-k-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-project</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/camel-k-core/runtime/pom.xml
+++ b/camel-k-core/runtime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-core-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-core/support/pom.xml
+++ b/camel-k-core/support/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-core-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-cron/deployment/pom.xml
+++ b/camel-k-cron/deployment/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-cron-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-cron/impl/pom.xml
+++ b/camel-k-cron/impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-cron-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-cron/pom.xml
+++ b/camel-k-cron/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-project</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/camel-k-cron/runtime/pom.xml
+++ b/camel-k-cron/runtime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-cron-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-knative/impl/pom.xml
+++ b/camel-k-knative/impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-knative-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-knative/pom.xml
+++ b/camel-k-knative/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-project</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/camel-k-resume-kafka/deployment/pom.xml
+++ b/camel-k-resume-kafka/deployment/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-resume-kafka-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-resume-kafka/impl/pom.xml
+++ b/camel-k-resume-kafka/impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-resume-kafka-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-resume-kafka/pom.xml
+++ b/camel-k-resume-kafka/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-project</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/camel-k-resume-kafka/runtime/pom.xml
+++ b/camel-k-resume-kafka/runtime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-resume-kafka-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-runtime/deployment/pom.xml
+++ b/camel-k-runtime/deployment/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-runtime/pom.xml
+++ b/camel-k-runtime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-project</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/camel-k-runtime/runtime/pom.xml
+++ b/camel-k-runtime/runtime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-webhook/deployment/pom.xml
+++ b/camel-k-webhook/deployment/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-webhook-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-webhook/impl/pom.xml
+++ b/camel-k-webhook/impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-webhook-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-k-webhook/pom.xml
+++ b/camel-k-webhook/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-project</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/camel-k-webhook/runtime/pom.xml
+++ b/camel-k-webhook/runtime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-webhook-parent</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.camel.k</groupId>
     <artifactId>camel-k-runtime-project</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>3.20.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/examples/cron/pom.xml
+++ b/examples/cron/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-examples</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/groovy/pom.xml
+++ b/examples/groovy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-examples</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-examples</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/js/pom.xml
+++ b/examples/js/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-examples</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/kafka-source-s3/pom.xml
+++ b/examples/kafka-source-s3/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-examples</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/kamelets-discovery/pom.xml
+++ b/examples/kamelets-discovery/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-examples</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/kamelets/pom.xml
+++ b/examples/kamelets/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-examples</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/knative/pom.xml
+++ b/examples/knative/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-examples</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/kotlin/pom.xml
+++ b/examples/kotlin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-examples</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-project</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/xml/pom.xml
+++ b/examples/xml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-examples</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/yaml/pom.xml
+++ b/examples/yaml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-examples</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/itests/camel-k-itests-core/pom.xml
+++ b/itests/camel-k-itests-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-cron/pom.xml
+++ b/itests/camel-k-itests-cron/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-kamelet/pom.xml
+++ b/itests/camel-k-itests-kamelet/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-knative-consumer/pom.xml
+++ b/itests/camel-k-itests-knative-consumer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-knative-env-from-properties/pom.xml
+++ b/itests/camel-k-itests-knative-env-from-properties/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-knative-env-from-registry/pom.xml
+++ b/itests/camel-k-itests-knative-env-from-registry/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-knative-producer/pom.xml
+++ b/itests/camel-k-itests-knative-producer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-knative-sinkbinding/pom.xml
+++ b/itests/camel-k-itests-knative-sinkbinding/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-knative-source-groovy/pom.xml
+++ b/itests/camel-k-itests-knative-source-groovy/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-knative-source-java/pom.xml
+++ b/itests/camel-k-itests-knative-source-java/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-knative-source-js/pom.xml
+++ b/itests/camel-k-itests-knative-source-js/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-knative-source-xml/pom.xml
+++ b/itests/camel-k-itests-knative-source-xml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-knative-source-yaml/pom.xml
+++ b/itests/camel-k-itests-knative-source-yaml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-knative/pom.xml
+++ b/itests/camel-k-itests-knative/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-loader-groovy/pom.xml
+++ b/itests/camel-k-itests-loader-groovy/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-loader-java/pom.xml
+++ b/itests/camel-k-itests-loader-java/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-loader-js/pom.xml
+++ b/itests/camel-k-itests-loader-js/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-loader-jsh/pom.xml
+++ b/itests/camel-k-itests-loader-jsh/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-loader-kotlin/pom.xml
+++ b/itests/camel-k-itests-loader-kotlin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-loader-polyglot/pom.xml
+++ b/itests/camel-k-itests-loader-polyglot/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-loader-xml/pom.xml
+++ b/itests/camel-k-itests-loader-xml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-loader-yaml/pom.xml
+++ b/itests/camel-k-itests-loader-yaml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-runtime-xml/pom.xml
+++ b/itests/camel-k-itests-runtime-xml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-runtime-yaml/pom.xml
+++ b/itests/camel-k-itests-runtime-yaml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-runtime/pom.xml
+++ b/itests/camel-k-itests-runtime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/camel-k-itests-webhook/pom.xml
+++ b/itests/camel-k-itests-webhook/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-project</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,8 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.k</groupId>
     <artifactId>camel-k-runtime-project</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <!-- Make sure that this version is aligned with the Camel Version as it is the convention used in Camel K -->
+    <version>3.20.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -44,8 +45,6 @@
         <camel-quarkus-version>2.16.0</camel-quarkus-version>
         <quarkus-version>2.16.0.Final</quarkus-version>
         <quarkus-platform-version>2.16.0.Final</quarkus-platform-version>
-        <!-- The quarkus camel bom may differ from quarkus platfom -->
-        <quarkus-camel-bom-version>2.16.0.Final</quarkus-camel-bom-version>
         <quarkus-native-builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.2.0.0-Final-java11</quarkus-native-builder-image>
 
         <!-- camel-k-runtime specific -->
@@ -404,7 +403,7 @@
             <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-camel-bom</artifactId>
-                <version>${quarkus-camel-bom-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -13,7 +13,6 @@ Usage: ./script/bump.sh [options]
 --camel-quarkus           Bump Camel-Quarkus version
 --quarkus                 Bump Quarkus version
 --quarkus-platform        Bump Quarkus platform version (could differ from quarkus core)
---quarkus-camel-bom       Bump Quarkus Camel BOM version (could differ from quarkus platform)
 --help                    This help message
 
 Example: ./script/bump.sh --version 1.14.0-SNAPSHOT --camel 3.16.0
@@ -26,7 +25,6 @@ CAMEL=""
 CAMELQUARKUS=""
 QUARKUS=""
 QUARKUSPLATFORM=""
-QUARKUSCAMELBOM=""
 
 main() {
   parse_args $@
@@ -56,11 +54,6 @@ main() {
   if [[ ! -z "$QUARKUSPLATFORM" ]]; then
     mvn versions:set-property -Dproperty="quarkus-platform-version" -DnewVersion="$QUARKUSPLATFORM" -DgenerateBackupPoms=false
     echo "Quarkus platform version set to $QUARKUSPLATFORM"
-  fi
-
-  if [[ ! -z "$QUARKUSCAMELBOM" ]]; then
-    mvn versions:set-property -Dproperty="quarkus-camel-bom-version" -DnewVersion="$QUARKUSCAMELBOM" -DgenerateBackupPoms=false
-    echo "Quarkus Camel BOM version set to $QUARKUSCAMELBOM"
   fi
 }
 
@@ -92,10 +85,6 @@ parse_args(){
         --quarkus-platform)
           shift
           QUARKUSPLATFORM="$1"
-          ;;
-        --quarkus-camel-bom)
-          shift
-          QUARKUSCAMELBOM="$1"
           ;;
         *)
           echo "❗ unknown argument: $1"

--- a/support/camel-k-annotations/pom.xml
+++ b/support/camel-k-annotations/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-support</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/support/camel-k-apt/pom.xml
+++ b/support/camel-k-apt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-support</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/support/camel-k-catalog-model/pom.xml
+++ b/support/camel-k-catalog-model/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-support</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/support/camel-k-catalog/pom.xml
+++ b/support/camel-k-catalog/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-support</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/support/camel-k-itests-support/camel-k-itests-loader-inspector/pom.xml
+++ b/support/camel-k-itests-support/camel-k-itests-loader-inspector/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests-support</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/support/camel-k-itests-support/camel-k-itests-runtime-inspector/pom.xml
+++ b/support/camel-k-itests-support/camel-k-itests-runtime-inspector/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-itests-support</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/support/camel-k-itests-support/pom.xml
+++ b/support/camel-k-itests-support/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-support</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/support/camel-k-maven-logging/pom.xml
+++ b/support/camel-k-maven-logging/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-support</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/support/camel-k-maven-plugin/pom.xml
+++ b/support/camel-k-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-support</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <prerequisites>

--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -29,18 +29,16 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.k</groupId>
     <artifactId>camel-k-runtime-bom</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>3.20.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
         <!-- reproduceable builds: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
-        <project.build.outputTimestamp>1676883627</project.build.outputTimestamp>
+        <project.build.outputTimestamp>1678701535</project.build.outputTimestamp>
         <jolokia-version>1.7.2</jolokia-version>
         <maven-enforcer-plugin-version>3.2.1</maven-enforcer-plugin-version>
         <maven-version>3.6.3</maven-version>
         <quarkus-platform-version>2.16.0.Final</quarkus-platform-version>
-        <!-- The quarkus camel bom may differ from quarkus platfom -->
-        <quarkus-camel-bom-version>2.16.0.Final</quarkus-camel-bom-version>
     </properties>
 
     <developers>
@@ -100,7 +98,7 @@
             <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-camel-bom</artifactId>
-                <version>${quarkus-camel-bom-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/support/camel-k-test/pom.xml
+++ b/support/camel-k-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-support</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/support/pom.xml
+++ b/support/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-project</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>3.20.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
<!-- Description -->
From now on, we will align our release version convention to Camel in order to simplify the detection of which Camel version is used by the runtime.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat: version aligned to Apache Camel
```
