### PR TITLE
Revert "Remove camel-k-master, replacement is camel-quarkus-kubernetes"

### DIFF
--- a/camel-k-master/deployment/pom.xml
+++ b/camel-k-master/deployment/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.k</groupId>
+        <artifactId>camel-k-master-parent</artifactId>
+        <version>1.18.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-k-master-deployment</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-master</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-master-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-kubernetes-deployment</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus-version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/camel-k-master/deployment/src/main/java/org/apache/camel/k/quarkus/master/deployment/MasterFeature.java
+++ b/camel-k-master/deployment/src/main/java/org/apache/camel/k/quarkus/master/deployment/MasterFeature.java
@@ -14,23 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.k.quarkus.master.deployment;
 
-new File(basedir, "catalog.yaml").withReader {
-    def catalog = new groovy.yaml.YamlSlurper().parse(it)
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
 
-    assert catalog.spec.loaders['jsh'] == null
-    assert catalog.spec.loaders['kts'] == null
-    assert catalog.spec.loaders['js'] == null
-    assert catalog.spec.loaders['groovy'] == null
+public class MasterFeature {
+    private static final String FEATURE = "camel-k-master";
 
-    assert catalog.spec.loaders['java'] != null
-    assert catalog.spec.loaders['xml'] != null
-    assert catalog.spec.loaders['yaml'] != null
-
-    assert catalog.spec.artifacts['camel-quarkus-jackson-avro'] != null
-    assert catalog.spec.artifacts['camel-quarkus-csimple'] == null
-    assert catalog.spec.artifacts['camel-quarkus-disruptor'] == null
-
-    assert catalog.spec.runtime.capabilities['master'] == null
-    assert catalog.spec.artifacts['camel-k-master'] == null
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
 }

--- a/camel-k-master/impl/pom.xml
+++ b/camel-k-master/impl/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.k</groupId>
+        <artifactId>camel-k-master-parent</artifactId>
+        <version>1.18.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-k-master-impl</artifactId>
+
+    <dependencies>
+
+        <!-- ****************************** -->
+        <!--                                -->
+        <!-- RUNTIME                        -->
+        <!--                                -->
+        <!-- ****************************** -->
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-kubernetes</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-core-support</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-apt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/camel-k-master/impl/src/main/java/org/apache/camel/k/master/MasterContextCustomizer.java
+++ b/camel-k-master/impl/src/main/java/org/apache/camel/k/master/MasterContextCustomizer.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.k.master;
+
+import java.util.Collections;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.component.kubernetes.cluster.KubernetesClusterService;
+import org.apache.camel.component.kubernetes.cluster.LeaseResourceType;
+import org.apache.camel.k.ContextCustomizer;
+import org.apache.camel.k.annotation.Customizer;
+import org.apache.camel.support.cluster.RebalancingCamelClusterService;
+import org.apache.camel.util.ObjectHelper;
+
+@Customizer("master")
+public class MasterContextCustomizer implements ContextCustomizer {
+    @Deprecated
+    private String configMapName;
+    private String kubernetesResourceName;
+    private LeaseResourceType leaseResourceType;
+    private Boolean rebalancing;
+    private String labelKey;
+    private String labelValue;
+
+    @Override
+    public void apply(CamelContext camelContext) {
+        try {
+            KubernetesClusterService clusterService = new KubernetesClusterService();
+            String resourceName = this.kubernetesResourceName;
+            if (ObjectHelper.isEmpty(resourceName)) {
+                resourceName = this.configMapName;
+            }
+            if (ObjectHelper.isNotEmpty(resourceName)) {
+                clusterService.setKubernetesResourceName(resourceName);
+            }
+            if (ObjectHelper.isNotEmpty(this.labelKey) && ObjectHelper.isNotEmpty(this.labelValue)) {
+                clusterService.setClusterLabels(Collections.singletonMap(this.labelKey, this.labelValue));
+            }
+            if (this.leaseResourceType != null) {
+                clusterService.setLeaseResourceType(this.leaseResourceType);
+            }
+
+            if (this.rebalancing == null || this.rebalancing) {
+                RebalancingCamelClusterService rebalancingService = new RebalancingCamelClusterService(clusterService, clusterService.getRenewDeadlineMillis());
+                camelContext.addService(rebalancingService);
+            } else {
+                camelContext.addService(clusterService);
+            }
+        } catch (Exception ex) {
+            throw new RuntimeCamelException(ex);
+        }
+    }
+
+    public String getKubernetesResourceName() {
+        return kubernetesResourceName;
+    }
+
+    public void setKubernetesResourceName(String kubernetesResourceName) {
+        this.kubernetesResourceName = kubernetesResourceName;
+    }
+
+    public LeaseResourceType getLeaseResourceType() {
+        return leaseResourceType;
+    }
+
+    public void setLeaseResourceType(LeaseResourceType leaseResourceType) {
+        this.leaseResourceType = leaseResourceType;
+    }
+
+    public Boolean getRebalancing() {
+        return rebalancing;
+    }
+
+    public void setRebalancing(Boolean rebalancing) {
+        this.rebalancing = rebalancing;
+    }
+
+    public String getConfigMapName() {
+        return configMapName;
+    }
+
+    public void setConfigMapName(String configMapName) {
+        this.configMapName = configMapName;
+    }
+
+    public String getLabelKey() {
+        return labelKey;
+    }
+
+    public void setLabelKey(String labelKey) {
+        this.labelKey = labelKey;
+    }
+
+    public String getLabelValue() {
+        return labelValue;
+    }
+
+    public void setLabelValue(String labelValue) {
+        this.labelValue = labelValue;
+    }
+
+}

--- a/camel-k-master/pom.xml
+++ b/camel-k-master/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.k</groupId>
+        <artifactId>camel-k-runtime-project</artifactId>
+        <version>1.18.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+
+    <artifactId>camel-k-master-parent</artifactId>
+
+    <modules>
+        <module>impl</module>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+</project>

--- a/camel-k-master/runtime/pom.xml
+++ b/camel-k-master/runtime/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.k</groupId>
+        <artifactId>camel-k-master-parent</artifactId>
+        <version>1.18.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-k-master</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-master-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-master</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-kubernetes</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus-version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/itests/camel-k-itests-master/pom.xml
+++ b/itests/camel-k-itests-master/pom.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.k</groupId>
+        <artifactId>camel-k-itests</artifactId>
+        <version>1.18.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-k-itests-master</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-master</artifactId>
+        </dependency>
+
+        <!-- quarkus dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jsonb</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
+        <!-- The following dependencies guarantee that this module is built after them.  -->
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-runtime-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-master-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.additional-build-args>--language:js</quarkus.native.additional-build-args>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/itests/camel-k-itests-master/src/main/java/org/apache/camel/k/quarkus/master/Application.java
+++ b/itests/camel-k-itests-master/src/main/java/org/apache/camel/k/quarkus/master/Application.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.k.quarkus.master;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.kubernetes.cluster.KubernetesClusterService;
+import org.apache.camel.support.cluster.RebalancingCamelClusterService;
+
+@Path("/test")
+@ApplicationScoped
+public class Application {
+    @Inject
+    CamelContext context;
+
+    @GET
+    @Path("/inspect")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject inspect() {
+        var rebalancingService = context.hasService(RebalancingCamelClusterService.class);
+        var service = (KubernetesClusterService) rebalancingService.getDelegate();
+
+        return Json.createObjectBuilder()
+            .add("cluster-service", service != null ? rebalancingService.getClass().getName() : "")
+            .add("cluster-service-res", service != null ? service.getKubernetesResourceName() : "")
+            .build();
+    }
+}

--- a/itests/camel-k-itests-master/src/main/resources/application.properties
+++ b/itests/camel-k-itests-master/src/main/resources/application.properties
@@ -1,0 +1,33 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+#
+# Quarkus
+#
+quarkus.log.console.enable = false
+quarkus.banner.enabled     = false
+
+#
+# Quarkus :: Camel
+#
+quarkus.camel.routes-discovery.enabled = false
+
+#
+# Camel K
+#
+camel.k.customizer.master.enabled = true
+camel.k.customizer.master.kubernetes-resource-name = camel-k-res

--- a/itests/camel-k-itests-master/src/test/java/org/apache/camel/k/quarkus/master/MasterIT.java
+++ b/itests/camel-k-itests-master/src/test/java/org/apache/camel/k/quarkus/master/MasterIT.java
@@ -14,23 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.k.quarkus.master;
 
-new File(basedir, "catalog.yaml").withReader {
-    def catalog = new groovy.yaml.YamlSlurper().parse(it)
+import io.quarkus.test.junit.NativeImageTest;
 
-    assert catalog.spec.loaders['jsh'] == null
-    assert catalog.spec.loaders['kts'] == null
-    assert catalog.spec.loaders['js'] == null
-    assert catalog.spec.loaders['groovy'] == null
-
-    assert catalog.spec.loaders['java'] != null
-    assert catalog.spec.loaders['xml'] != null
-    assert catalog.spec.loaders['yaml'] != null
-
-    assert catalog.spec.artifacts['camel-quarkus-jackson-avro'] != null
-    assert catalog.spec.artifacts['camel-quarkus-csimple'] == null
-    assert catalog.spec.artifacts['camel-quarkus-disruptor'] == null
-
-    assert catalog.spec.runtime.capabilities['master'] == null
-    assert catalog.spec.artifacts['camel-k-master'] == null
+@NativeImageTest
+public class MasterIT extends MasterTest {
 }

--- a/itests/camel-k-itests-master/src/test/java/org/apache/camel/k/quarkus/master/MasterTest.java
+++ b/itests/camel-k-itests-master/src/test/java/org/apache/camel/k/quarkus/master/MasterTest.java
@@ -14,23 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.k.quarkus.master;
 
-new File(basedir, "catalog.yaml").withReader {
-    def catalog = new groovy.yaml.YamlSlurper().parse(it)
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.path.json.JsonPath;
+import org.apache.camel.support.cluster.RebalancingCamelClusterService;
+import org.junit.jupiter.api.Test;
 
-    assert catalog.spec.loaders['jsh'] == null
-    assert catalog.spec.loaders['kts'] == null
-    assert catalog.spec.loaders['js'] == null
-    assert catalog.spec.loaders['groovy'] == null
+import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
-    assert catalog.spec.loaders['java'] != null
-    assert catalog.spec.loaders['xml'] != null
-    assert catalog.spec.loaders['yaml'] != null
+@QuarkusTest
+public class MasterTest {
+    @Test
+    public void hasClusterService() {
+        JsonPath path = when()
+            .get("/test/inspect")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath();
 
-    assert catalog.spec.artifacts['camel-quarkus-jackson-avro'] != null
-    assert catalog.spec.artifacts['camel-quarkus-csimple'] == null
-    assert catalog.spec.artifacts['camel-quarkus-disruptor'] == null
-
-    assert catalog.spec.runtime.capabilities['master'] == null
-    assert catalog.spec.artifacts['camel-k-master'] == null
+        assertThat(path.getString("cluster-service")).isEqualTo(RebalancingCamelClusterService.class.getName());
+        assertThat(path.getString("cluster-service-res")).isEqualTo("camel-k-res");
+    }
 }

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -45,6 +45,7 @@
         <module>camel-k-itests-runtime-yaml</module>
 
         <module>camel-k-itests-cron</module>
+        <module>camel-k-itests-master</module>
         <module>camel-k-itests-knative</module>
         <module>camel-k-itests-knative-env-from-registry</module>
         <module>camel-k-itests-knative-env-from-properties</module>

--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,7 @@
         <module>camel-k-cron</module>
         <module>camel-k-cloudevents</module>
         <module>camel-k-knative</module>
+        <module>camel-k-master</module>
         <module>camel-k-webhook</module>
         <module>camel-k-runtime</module>
         <module>camel-k-resume-kafka</module>
@@ -451,6 +452,21 @@
             <dependency>
                 <groupId>org.apache.camel.k</groupId>
                 <artifactId>camel-k-cloudevents-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-master-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-master</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-master-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/support/camel-k-maven-plugin/src/it/generate-catalog-with-exclusions/pom.xml
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog-with-exclusions/pom.xml
@@ -37,6 +37,7 @@
         <dataformats.exclusion.list>avro-jackson</dataformats.exclusion.list>
         <languages.exclusion.list>csimple</languages.exclusion.list>
         <components.exclusion.list>disruptor,disruptor-vm</components.exclusion.list>
+        <capabilities.exclusion.list>master</capabilities.exclusion.list>
     </properties>
 
     <build>

--- a/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
@@ -44,6 +44,8 @@ new File(basedir, "catalog.yaml").withReader {
     assert catalog.spec.runtime.capabilities['tracing'].dependencies[0].artifactId == 'camel-quarkus-opentracing'
     assert catalog.spec.runtime.capabilities['telemetry'].dependencies[0].groupId == 'org.apache.camel.quarkus'
     assert catalog.spec.runtime.capabilities['telemetry'].dependencies[0].artifactId == 'camel-quarkus-opentelemetry'
+    assert catalog.spec.runtime.capabilities['master'].dependencies[0].groupId == 'org.apache.camel.k'
+    assert catalog.spec.runtime.capabilities['master'].dependencies[0].artifactId == 'camel-k-master'
 
     assert catalog.spec.loaders['groovy'].groupId == 'org.apache.camel.quarkus'
     assert catalog.spec.loaders['groovy'].artifactId == 'camel-quarkus-groovy-dsl'
@@ -83,6 +85,9 @@ new File(basedir, "catalog.yaml").withReader {
 
     assert catalog.metadata.labels['camel.apache.org/runtime.version'] == runtimeVersion
 
+    catalog.spec.artifacts['camel-k-master'].with {
+        schemes == null
+    }
     catalog.spec.artifacts['camel-k-cron'].with {
         schemes == null
     }

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
@@ -234,6 +234,19 @@ public class GenerateCatalogMojo extends AbstractMojo {
                         CamelCapability.forArtifact(
                                 "org.apache.camel.quarkus", "camel-quarkus-opentelemetry"));
             }
+            if (capabilitiesExclusionList != null && !capabilitiesExclusionList.contains("master")) {
+                runtimeSpec.putCapability(
+                    "master",
+                    CamelCapability.forArtifact(
+                        "org.apache.camel.k", "camel-k-master"));
+
+                catalogSpec.putArtifact(
+                    new CamelArtifact.Builder()
+                        .groupId("org.apache.camel.k")
+                        .artifactId("camel-k-master")
+                        .build()
+                );
+            }
             if (capabilitiesExclusionList != null && !capabilitiesExclusionList.contains("resume-kafka")) {
                 runtimeSpec.putCapability(
                         "resume-kafka",

--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -162,6 +162,16 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-master-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-master</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
                 <artifactId>camel-k-knative-impl</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Reverts apache/camel-k-runtime#982

While we find a proper design for master trait in https://github.com/apache/camel-k/pull/4121, we need to revert these changes in order not to break the smoke test and the nightly test procedure. We may re-revert this one if it makes sense once all is fixed on Camel K side.

Closes https://github.com/apache/camel-k/issues/4138