### PR TITLE
fix(doc): missing language documentation in camel-k 1.12.x version

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -18,4 +18,4 @@
 # The main part of this distributed component is in camel-k docs
 
 name: camel-k
-version: next
+version: 1.12.x


### PR DESCRIPTION
resolves apache/camel-k#4176

The language documentation is missing from the camel-k 1.12.x version documentation

**Release Note**
```release-note
Fix website doc camel-k version
```
