### PR TITLE
fix(#1029): Include miscellaneous components in Camel catalog

### DIFF
--- a/support/camel-k-catalog-model/src/main/java/org/apache/camel/k/catalog/model/CatalogOtherDefinition.java
+++ b/support/camel-k-catalog-model/src/main/java/org/apache/camel/k/catalog/model/CatalogOtherDefinition.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.k.catalog.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class CatalogOtherDefinition extends CatalogDefinition {
+    private String label;
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Container {
+        private final CatalogOtherDefinition delegate;
+
+        @JsonCreator
+        public Container(
+            @JsonProperty("other") CatalogOtherDefinition delegate) {
+            this.delegate = delegate;
+        }
+
+        public CatalogOtherDefinition unwrap() {
+            return delegate;
+        }
+    }
+}

--- a/support/camel-k-catalog-model/src/main/java/org/apache/camel/k/catalog/model/CatalogSupport.java
+++ b/support/camel-k-catalog-model/src/main/java/org/apache/camel/k/catalog/model/CatalogSupport.java
@@ -44,4 +44,8 @@ public final class CatalogSupport {
     public static CatalogDataFormatDefinition unmarshallDataFormat(String json) {
         return unmarshall(json, CatalogDataFormatDefinition.Container.class).unwrap();
     }
+
+    public static CatalogOtherDefinition unmarshallOther(String json) {
+        return unmarshall(json, CatalogOtherDefinition.Container.class).unwrap();
+    }
 }

--- a/support/camel-k-maven-plugin/src/it/generate-catalog-with-exclusions/pom.xml
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog-with-exclusions/pom.xml
@@ -37,6 +37,7 @@
         <dataformats.exclusion.list>avro-jackson</dataformats.exclusion.list>
         <languages.exclusion.list>csimple</languages.exclusion.list>
         <components.exclusion.list>disruptor,disruptor-vm</components.exclusion.list>
+        <others.exclusion.list>jta,redis</others.exclusion.list>
         <capabilities.exclusion.list>master</capabilities.exclusion.list>
     </properties>
 

--- a/support/camel-k-maven-plugin/src/it/generate-catalog-with-exclusions/verify.groovy
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog-with-exclusions/verify.groovy
@@ -31,6 +31,10 @@ new File(basedir, "catalog.yaml").withReader {
     assert catalog.spec.artifacts['camel-quarkus-csimple'] == null
     assert catalog.spec.artifacts['camel-quarkus-disruptor'] == null
 
+    assert catalog.spec.artifacts['camel-quarkus-debug'] != null
+    assert catalog.spec.artifacts['camel-quarkus-jta'] == null
+    assert catalog.spec.artifacts['camel-quarkus-redis'] == null
+
     assert catalog.spec.runtime.capabilities['master'] == null
     assert catalog.spec.artifacts['camel-k-master'] == null
 }


### PR DESCRIPTION
- Includes Camel components categorized as miscellaneous/other when building the Camel catalog via Maven plugin

**Release Note**
```release-note
fix: Include miscellaneous components into Camel catalog
```
