### PR TITLE
Pin jackson-databind dependency in maven-invoker-plugin

### DIFF
--- a/support/camel-k-maven-plugin/pom.xml
+++ b/support/camel-k-maven-plugin/pom.xml
@@ -229,6 +229,22 @@
                         <artifactId>groovy-xml</artifactId>
                         <version>${groovy-version}</version>
                     </dependency>
+                    <!-- the jackson2-version is defined in the camel-dependencies parent pom -->
+                    <dependency>
+                        <groupId>com.fasterxml.jackson.dataformat</groupId>
+                        <artifactId>jackson-dataformat-yaml</artifactId>
+                        <version>${jackson2-version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.fasterxml.jackson.dataformat</groupId>
+                        <artifactId>jackson-dataformat-xml</artifactId>
+                        <version>${jackson2-version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                        <version>${jackson2-version}</version>
+                    </dependency>
                     <dependency>
                         <groupId>org.apache.commons</groupId>
                         <artifactId>commons-collections4</artifactId>


### PR DESCRIPTION
Pin jackson-databind version as defined in the camel-dependencies parent pom and not use the transient version set in groovy

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
