### PR TITLE
Revert "build(deps): bump logstash-logback-encoder from 7.3 to 7.4"

### DIFF
--- a/support/camel-k-maven-logging/pom.xml
+++ b/support/camel-k-maven-logging/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>7.4</version>
+            <version>7.3</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
This reverts commit c1b49e5bffe9d5c1d0a7e929eacf575474735d1c.

7.4 version dropped support for logback 1.2
https://github.com/logfellow/logstash-logback-encoder/releases/tag/logstash-logback-encoder-7.4

it causes a `NoSuchMethodError: 'java.time.Instant ch.qos.logback.classic.spi.ILoggingEvent.getInstant()'` when using build=routine in camel-k

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Revert logstash-logback-encoder upgrade from 7.4 to 7.3
```
