### PR TITLE
Update native image to ubi-quarkus-mandrel-builder-image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <camel-quarkus-version>2.16.0</camel-quarkus-version>
         <quarkus-version>2.16.0.Final</quarkus-version>
         <quarkus-platform-version>2.16.0.Final</quarkus-platform-version>
-        <quarkus-native-builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.2.0.0-Final-java11</quarkus-native-builder-image>
+        <quarkus-native-builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.2.0.0-Final-java11</quarkus-native-builder-image>
 
         <!-- camel-k-runtime specific -->
         <groovy-version>3.0.17</groovy-version>


### PR DESCRIPTION
ubi-quarkus-mandrel is deprecated, in favor of ubi-quarkus-mandrel-builder-image 
https://quay.io/repository/quarkus/ubi-quarkus-mandrel?tab=info

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
