### PR TITLE
Add slf4j-api as dependency, it is required in camel-k to overlay in maven lib

### DIFF
--- a/support/camel-k-maven-logging/pom.xml
+++ b/support/camel-k-maven-logging/pom.xml
@@ -76,6 +76,12 @@
     <dependencies>
         <!-- structural logging: we only need this dependencies to be part of the overlay package, reason why are marked as provided -->
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j-api-version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>${logback-version}</version>


### PR DESCRIPTION
<!-- Description -->

`logback-version` is defined in parent camel-dependencies pom and the version is 1.4.8 which is incompatible with slf4j 1.7  packaged in maven 3.8.6 (bundled in Camel K operator), so slf4j-api 2.0 should be defined as dependency, to be retrieved as part of the Camel K operator build.
This is to fix https://github.com/apache/camel-k/issues/4882


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
````4
