### PR TITLE
Fix quarkus-maven-plugin to use the quarkus-platform-version property (#86)

### DIFF
--- a/examples/cron/pom.xml
+++ b/examples/cron/pom.xml
@@ -72,7 +72,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/groovy/pom.xml
+++ b/examples/groovy/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/js/pom.xml
+++ b/examples/js/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/kafka-source-s3/pom.xml
+++ b/examples/kafka-source-s3/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/kamelets-discovery/pom.xml
+++ b/examples/kamelets-discovery/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/kamelets/pom.xml
+++ b/examples/kamelets/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/knative/pom.xml
+++ b/examples/knative/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/kotlin/pom.xml
+++ b/examples/kotlin/pom.xml
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/xml/pom.xml
+++ b/examples/xml/pom.xml
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/yaml/pom.xml
+++ b/examples/yaml/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-version}</version>
+                <version>${quarkus-platform-version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -162,7 +162,7 @@
                     <plugin>
                         <groupId>${quarkus-platform-group}</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
-                        <version>${quarkus-version}</version>
+                        <version>${quarkus-platform-version}</version>
                         <executions>
                             <execution>
                                 <id>dev</id>

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
                 <plugin>
                     <groupId>${quarkus-platform-group}</groupId>
                     <artifactId>quarkus-maven-plugin</artifactId>
-                    <version>${quarkus-version}</version>
+                    <version>${quarkus-platform-version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
It may happen the io.quarkus version differ to quarkus.platform version so we have to set quarkus-maven-plugin to follow the qurarkus platform version

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
