### PR TITLE
The camel-quarkus dependencies must come exclusively from quarkus-camel-bom (3.2.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
         <camel-version>4.0.3</camel-version>
 
         <!-- quarkus -->
-        <camel-quarkus-version>3.2.3</camel-quarkus-version>
         <quarkus-version>3.2.9.Final</quarkus-version>
         <quarkus-platform-group>io.quarkus.platform</quarkus-platform-group>
         <quarkus-platform-version>3.2.9.Final</quarkus-platform-version>

--- a/support/camel-k-maven-plugin/pom.xml
+++ b/support/camel-k-maven-plugin/pom.xml
@@ -72,12 +72,10 @@
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-catalog</artifactId>
-            <version>${camel-quarkus-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-core</artifactId>
-            <version>${camel-quarkus-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
@@ -171,7 +169,6 @@
                     <scriptVariables>
                         <runtimeVersion>${project.version}</runtimeVersion>
                         <camelVersion>${camel-version}</camelVersion>
-                        <camelQuarkusVersion>${camel-quarkus-version}</camelQuarkusVersion>
                         <quarkusVersion>${quarkus-version}</quarkusVersion>
                         <quarkusNativeBuilderImage>${quarkus-native-builder-image}</quarkusNativeBuilderImage>
                     </scriptVariables>

--- a/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
@@ -21,9 +21,6 @@ new File(basedir, "catalog.yaml").withReader {
     assert catalog.spec.runtime.version == runtimeVersion
     assert catalog.spec.runtime.applicationClass == 'io.quarkus.bootstrap.runner.QuarkusEntryPoint'
     assert catalog.spec.runtime.metadata['camel.version'] == camelVersion
-    // Re-enabled this when the version will be the same again
-    //assert catalog.spec.runtime.metadata['quarkus.version'] == quarkusVersion
-    assert catalog.spec.runtime.metadata['camel-quarkus.version'] == camelQuarkusVersion
     assert catalog.spec.runtime.metadata['quarkus.native-builder-image'] == quarkusNativeBuilderImage
 
     assert catalog.spec.runtime.dependencies.any {


### PR DESCRIPTION

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
