### PR TITLE
Fix: add classifier field to the maven artifact abstraction

### DIFF
--- a/support/camel-k-catalog-model/src/main/java/org/apache/camel/k/catalog/model/Artifact.java
+++ b/support/camel-k-catalog-model/src/main/java/org/apache/camel/k/catalog/model/Artifact.java
@@ -21,10 +21,11 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-@JsonPropertyOrder({"groupId", "artifactId", "version"})
+@JsonPropertyOrder({"groupId", "artifactId", "classifier", "version"})
 public interface Artifact extends Comparable<Artifact> {
     String getGroupId();
     String getArtifactId();
+    Optional<String> getClassifier();
     Optional<String> getVersion();
 
     @Override
@@ -33,6 +34,7 @@ public interface Artifact extends Comparable<Artifact> {
             .comparing(Artifact::getGroupId)
             .thenComparing(Artifact::getArtifactId)
             .thenComparing(Artifact::getVersion, Comparator.comparing(c -> c.orElse("")))
+            .thenComparing(Artifact::getClassifier, Comparator.comparing(c -> c.orElse("")))
             .compare(this, o);
     }
 
@@ -49,9 +51,39 @@ public interface Artifact extends Comparable<Artifact> {
             }
 
             @Override
+            public Optional<String> getClassifier() {
+                return Optional.empty();
+            }
+
+            @Override
             public Optional<String> getVersion() {
                 return Optional.empty();
             }
         };
     }
+
+    static Artifact from(String groupId, String artifactId, String classifier) {
+        return new Artifact() {
+            @Override
+            public String getGroupId() {
+                return groupId;
+            }
+
+            @Override
+            public String getArtifactId() {
+                return artifactId;
+            }
+
+            @Override
+            public Optional<String> getClassifier() {
+                return Optional.of(classifier);
+            }
+
+            @Override
+            public Optional<String> getVersion() {
+                return Optional.empty();
+            }
+        };
+    }
+
 }

--- a/support/camel-k-catalog-model/src/main/java/org/apache/camel/k/catalog/model/CamelCapability.java
+++ b/support/camel-k-catalog-model/src/main/java/org/apache/camel/k/catalog/model/CamelCapability.java
@@ -17,6 +17,7 @@
 package org.apache.camel.k.catalog.model;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.SortedSet;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -26,7 +27,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Value.Style(depluralize = true)
 @JsonDeserialize(builder = CamelCapability.Builder.class)
-@JsonPropertyOrder({"groupId", "artifactId", "version"})
+@JsonPropertyOrder({"groupId", "artifactId", "classifier","version"})
 public interface CamelCapability {
     @Value.Auxiliary
     @Value.Default
@@ -42,6 +43,14 @@ public interface CamelCapability {
     class Builder extends ImmutableCamelCapability.Builder {
         public Builder addDependency(String groupId, String artifactId) {
             return super.addDependencies(Artifact.from(groupId, artifactId));
+        }
+
+        public Builder addDependency(String groupId, String artifactId, Optional<String> classifier) {
+            if (classifier.isEmpty()) {
+                return super.addDependencies(Artifact.from(groupId, artifactId));
+            } else {
+                return super.addDependencies(Artifact.from(groupId, artifactId, classifier.get()));
+            }
         }
     }
 }

--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <!-- reproduceable builds: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
         <project.build.outputTimestamp>1702292687</project.build.outputTimestamp>
-        <jolokia-version>1.7.2</jolokia-version>
+        <jolokia-version>2.0.1</jolokia-version>
         <maven-enforcer-plugin-version>3.4.1</maven-enforcer-plugin-version>
         <maven-version>3.8.6</maven-version>
         <quarkus-platform-group>io.quarkus.platform</quarkus-platform-group>
@@ -173,12 +173,13 @@
             </dependency>
             <dependency>
                 <groupId>org.jolokia</groupId>
-                <artifactId>jolokia-jvm</artifactId>
+                <artifactId>jolokia-agent-jvm</artifactId>
                 <version>${jolokia-version}</version>
+                <classifier>javaagent</classifier>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jolokia</groupId>
-                        <artifactId>jolokia-core</artifactId>
+                        <artifactId>jolokia-server-core</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
Update jolokia to 2.0.0

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feature: add maven artifact classifier to the camel-k-catalog
update: jolokia 2.0.0
```
