### PR TITLE
feat(ci): Add nightly deploy for main and recent release branches

### DIFF
--- a/.github/actions/automatic-updates/action.yml
+++ b/.github/actions/automatic-updates/action.yml
@@ -22,6 +22,10 @@ inputs:
     type: string
   secretGithubToken:
     required: true
+  secretNexusUser:
+    required: true
+  secretNexusPw:
+    required: true
 
 runs:
   using: "composite"
@@ -82,3 +86,14 @@ runs:
         git config --local user.email "$CI_EMAIL"
         git config --local user.name "$CI_USER"
         git push "https://$CI_USER:$CI_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ inputs.branch-ref }}
+
+    - name: Deploy to ASF Snapshots Repository
+      shell: bash
+      env:
+        NEXUS_DEPLOY_USERNAME: ${{ inputs.secretNexusUser }}
+        NEXUS_DEPLOY_PASSWORD: ${{ inputs.secretNexusPw }}
+        MAVEN_OPTS: -Xmx3000m
+        MAVEN_ARGS: -V -ntp -Dhttp.keepAlive=false -e
+      # Deploy both artifacts and sources (may be required by Camel K)
+      run: |
+        ./mvnw ${MAVEN_ARGS} clean deploy -DskipTests -DskipITs --settings .github/asf-deploy-settings.xml

--- a/.github/workflows/nightly-automatic-updates.yml
+++ b/.github/workflows/nightly-automatic-updates.yml
@@ -39,6 +39,8 @@ jobs:
       with:
         branch-ref: "main"
         secretGithubToken: ${{ secrets.GITHUB_TOKEN }}
+        secretNexusUser: ${{ secrets.NEXUS_USER }}
+        secretNexusPw: ${{ secrets.NEXUS_PW }}
 
   release-3_2_x:
     if: github.repository == 'apache/camel-k-runtime'
@@ -56,6 +58,8 @@ jobs:
       with:
         branch-ref: "release-3.2.x"
         secretGithubToken: ${{ secrets.GITHUB_TOKEN }}
+        secretNexusUser: ${{ secrets.NEXUS_USER }}
+        secretNexusPw: ${{ secrets.NEXUS_PW }}
 
   release-3_6_x:
     if: github.repository == 'apache/camel-k-runtime'
@@ -73,3 +77,5 @@ jobs:
       with:
         branch-ref: "release-3.6.x"
         secretGithubToken: ${{ secrets.GITHUB_TOKEN }}
+        secretNexusUser: ${{ secrets.NEXUS_USER }}
+        secretNexusPw: ${{ secrets.NEXUS_PW }}


### PR DESCRIPTION
Nightly deploy is activated on the following branches:
* main
* release-3.6.x
* release-3.2.x

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(ci): Add nightly deploy for main and recent release branches
```
