### PR TITLE
fix(CI): Update setup-java to v4 due to github warnings

### DIFF
--- a/.github/actions/automatic-updates/action.yml
+++ b/.github/actions/automatic-updates/action.yml
@@ -46,14 +46,14 @@ runs:
       shell: bash
       env:
         CI_USER: "github-actions[bot]"
-        CI_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"      
+        CI_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
       run: |
         git config --local user.email "$CI_EMAIL"
-        git config --local user.name "$CI_USER"     
+        git config --local user.name "$CI_USER"
         git add CHANGELOG.md && git commit -m 'chore: update changelog' && echo "changelog=1" >> $GITHUB_ENV || echo "No changes to CHANGELOG.md"
 
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 17
@@ -65,7 +65,7 @@ runs:
       shell: bash
       env:
         CI_USER: "github-actions[bot]"
-        CI_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"      
+        CI_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
       run: |
         git config --local user.email "$CI_EMAIL"
         git config --local user.name "$CI_USER"
@@ -76,7 +76,7 @@ runs:
       if: env.sync == 1 || env.changelog == 1 || env.sbom == 1
       env:
         CI_USER: "github-actions[bot]"
-        CI_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"      
+        CI_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         CI_TOKEN: ${{ inputs.secretGithubToken }}
       run: |
         git config --local user.email "$CI_EMAIL"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
