### PR TITLE
fix: Disable noErrorHandler setting via user properties

### DIFF
--- a/camel-k-runtime/runtime/src/main/java/org/apache/camel/k/quarkus/ApplicationConfigSourceProvider.java
+++ b/camel-k-runtime/runtime/src/main/java/org/apache/camel/k/quarkus/ApplicationConfigSourceProvider.java
@@ -37,6 +37,11 @@ public class ApplicationConfigSourceProvider implements ConfigSourceProvider {
         final Map<String, String> appProperties = RuntimeSupport.loadApplicationProperties();
         final Map<String, String> usrProperties = RuntimeSupport.loadUserProperties();
 
+        if (usrProperties.containsKey("camel.k.errorHandler.ref")) {
+            // Pipe error handler configured - need to disable noErrorHandler behavior in Camel 4.4.0
+            usrProperties.put("camel.component.kamelet.noErrorHandler", "false");
+        }
+
         return List.of(
             new PropertiesConfigSource(sysProperties, "camel-k-sys", ConfigSource.DEFAULT_ORDINAL + 1000),
             new PropertiesConfigSource(appProperties, "camel-k-app", ConfigSource.DEFAULT_ORDINAL),


### PR DESCRIPTION
- Since Camel 4.4.0 the noErrorHandler default setting will disable the global Pipe error handler
- Disable the noErrorHandler setting on the camel-kamelet component when the Pipe error handler ref is set
- Relates to Camel K issue https://github.com/apache/camel-k/issues/5242

**Release Note**
```release-note
fix: Disable noErrorHandler setting via user properties
```
