### PR TITLE
Update quarkus platform to 3.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
         <camel-version>4.4.1</camel-version>
 
         <!-- quarkus -->
-        <quarkus-version>3.9.0</quarkus-version>
+        <quarkus-version>3.9.1</quarkus-version>
         <quarkus-platform-group>io.quarkus.platform</quarkus-platform-group>
-        <quarkus-platform-version>3.9.0</quarkus-platform-version>
+        <quarkus-platform-version>3.9.1</quarkus-platform-version>
         <quarkus-native-builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21</quarkus-native-builder-image>
 
         <!-- camel-k-runtime specific -->
@@ -418,13 +418,6 @@
                 <version>${quarkus-platform-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <!-- components -->
-            <dependency>
-                <groupId>org.apache.camel</groupId>
-                <artifactId>camel-cloudevents</artifactId>
-                <version>${camel-version}</version>
             </dependency>
 
             <!-- runtime -->

--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -39,7 +39,7 @@
         <maven-enforcer-plugin-version>3.4.1</maven-enforcer-plugin-version>
         <maven-version>3.8.6</maven-version>
         <quarkus-platform-group>io.quarkus.platform</quarkus-platform-group>
-        <quarkus-platform-version>3.9.0</quarkus-platform-version>
+        <quarkus-platform-version>3.9.1</quarkus-platform-version>
     </properties>
 
     <developers>


### PR DESCRIPTION
<!-- Description -->

The sync_cq.sh script is not going to work as it gets the `quarkus.version` from camel-quarkus which is quarkus-core, while camel-k-runtime uses the quarkus.platform which these versions may differ. 
There exists the quarkus-core 3.9.0, but quarkus platform is 3.9.1.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Update quarkus platform to 3.9.1
```
