### PR TITLE
Remove tracing capability

### DIFF
--- a/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
@@ -40,8 +40,6 @@ new File(basedir, "catalog.yaml").withReader {
     assert catalog.spec.runtime.capabilities['platform-http'].dependencies[0].artifactId == 'camel-quarkus-platform-http'
     assert catalog.spec.runtime.capabilities['circuit-breaker'].dependencies[0].groupId == 'org.apache.camel.quarkus'
     assert catalog.spec.runtime.capabilities['circuit-breaker'].dependencies[0].artifactId == 'camel-quarkus-microprofile-fault-tolerance'
-    assert catalog.spec.runtime.capabilities['tracing'].dependencies[0].groupId == 'org.apache.camel.quarkus'
-    assert catalog.spec.runtime.capabilities['tracing'].dependencies[0].artifactId == 'camel-quarkus-opentracing'
     assert catalog.spec.runtime.capabilities['telemetry'].dependencies[0].groupId == 'org.apache.camel.quarkus'
     assert catalog.spec.runtime.capabilities['telemetry'].dependencies[0].artifactId == 'camel-quarkus-opentelemetry'
     assert catalog.spec.runtime.capabilities['master'].dependencies[0].groupId == 'org.apache.camel.k'

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
@@ -484,10 +484,6 @@ public class GenerateCatalogMojo extends AbstractMojo {
         artifacts.add(Artifact.from("org.apache.camel.quarkus", "camel-quarkus-microprofile-fault-tolerance"));
         addCapabilityAndDependecies(runtimeSpec, catalogSpec, "circuit-breaker", artifacts, false);
 
-        artifacts.clear();
-        artifacts.add(Artifact.from("org.apache.camel.quarkus", "camel-quarkus-opentracing"));
-        addCapabilityAndDependecies(runtimeSpec, catalogSpec, "tracing", artifacts, false);
-
         // Telemetry capability
         artifacts.clear();
         artifacts.add(Artifact.from("org.apache.camel.quarkus", "camel-quarkus-opentelemetry"));


### PR DESCRIPTION
the camel-quarkus-opentracing is removed since camel-quarkus 3.0

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Remove tracing capability
```
