### PR TITLE
Remove runnerParentFirstArtifacts from quarkus-extension-maven-plugin

### DIFF
--- a/camel-k-core/runtime/pom.xml
+++ b/camel-k-core/runtime/pom.xml
@@ -56,14 +56,6 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <version>${quarkus-version}</version>
-                <configuration>
-                    <runnerParentFirstArtifacts>
-                        <runnerParentFirstArtifact>org.graalvm.sdk:graal-sdk</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.graalvm.js:js</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.graalvm.regex:regex</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.graalvm.truffle:truffle-api</runnerParentFirstArtifact>
-                    </runnerParentFirstArtifacts>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/camel-k-runtime/runtime/pom.xml
+++ b/camel-k-runtime/runtime/pom.xml
@@ -52,14 +52,6 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <version>${quarkus-version}</version>
-                <configuration>
-                    <runnerParentFirstArtifacts>
-                        <runnerParentFirstArtifact>org.graalvm.sdk:graal-sdk</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.graalvm.js:js</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.graalvm.regex:regex</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.graalvm.truffle:truffle-api</runnerParentFirstArtifact>
-                    </runnerParentFirstArtifacts>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
it seems not required anymore by examing the plugin doc

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
