### PR TITLE
Fix quarkus-version property to quarkus-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
             <dependency>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus-platform-version}</version>
+                <version>${quarkus-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/support/camel-k-runtime-bom/pom.xml
+++ b/support/camel-k-runtime-bom/pom.xml
@@ -40,6 +40,7 @@
         <maven-version>3.8.6</maven-version>
         <quarkus-platform-group>io.quarkus.platform</quarkus-platform-group>
         <quarkus-platform-version>3.9.1</quarkus-platform-version>
+        <quarkus-version>3.9.1</quarkus-version>
     </properties>
 
     <developers>
@@ -106,7 +107,7 @@
             <dependency>
                 <groupId>${quarkus-platform-group}</groupId>
                 <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus-platform-version}</version>
+                <version>${quarkus-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
<!-- Description -->
Use the specific `quarkus-version` to set the version of the `quarkus-bom` artifact, since it may differ from the quarkus-platform



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
