### PR TITLE
fix(trait): Telemetry trait properties change

### DIFF
--- a/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
+++ b/support/camel-k-maven-plugin/src/it/generate-catalog/verify.groovy
@@ -63,15 +63,15 @@ new File(basedir, "catalog.yaml").withReader {
     assert catalog.spec.runtime.capabilities['master'].runtimeProperties[2].key == 'quarkus.camel.cluster.kubernetes.resource-type'
     assert catalog.spec.runtime.capabilities['master'].runtimeProperties[2].value == '${camel.k.master.resourceType}'
     // Telemetry properties
-    assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[0].key == 'quarkus.opentelemetry.tracer.exporter.otlp.endpoint'
+    assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[0].key == 'quarkus.otel.exporter.otlp.traces.endpoint'
     assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[0].value == '${camel.k.telemetry.endpoint}'
-    assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[1].key == 'quarkus.opentelemetry.tracer.resource-attributes'
+    assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[1].key == 'quarkus.otel.resource.attributes'
     assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[1].value == '${camel.k.telemetry.serviceName}'
-    assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[2].key == 'quarkus.opentelemetry.tracer.sampler'
+    assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[2].key == 'quarkus.otel.traces.sampler'
     assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[2].value == '${camel.k.telemetry.sampler}'
-    assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[3].key == 'quarkus.opentelemetry.tracer.sampler.parent-based'
+    assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[3].key == 'quarkus.otel.traces.sampler.parent-based'
     assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[3].value == '${camel.k.telemetry.samplerParentBased}'
-    assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[4].key == 'quarkus.opentelemetry.tracer.sampler.ratio'
+    assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[4].key == 'quarkus.otel.traces.sampler.ratio'
     assert catalog.spec.runtime.capabilities['telemetry'].runtimeProperties[4].value == '${camel.k.telemetry.samplerRatio}'
 
     // Service Binding properties

--- a/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
+++ b/support/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateCatalogMojo.java
@@ -491,11 +491,11 @@ public class GenerateCatalogMojo extends AbstractMojo {
         artifacts.clear();
         artifacts.add(Artifact.from("org.apache.camel.quarkus", "camel-quarkus-opentelemetry"));
         properties.clear();
-        properties.add(Property.from("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", "${camel.k.telemetry.endpoint}"));
-        properties.add(Property.from("quarkus.opentelemetry.tracer.resource-attributes", "${camel.k.telemetry.serviceName}"));
-        properties.add(Property.from("quarkus.opentelemetry.tracer.sampler", "${camel.k.telemetry.sampler}"));
-        properties.add(Property.from("quarkus.opentelemetry.tracer.sampler.ratio", "${camel.k.telemetry.samplerRatio}"));
-        properties.add(Property.from("quarkus.opentelemetry.tracer.sampler.parent-based", "${camel.k.telemetry.samplerParentBased}"));
+        properties.add(Property.from("quarkus.otel.exporter.otlp.traces.endpoint", "${camel.k.telemetry.endpoint}"));
+        properties.add(Property.from("quarkus.otel.resource.attributes", "${camel.k.telemetry.serviceName}"));
+        properties.add(Property.from("quarkus.otel.traces.sampler", "${camel.k.telemetry.sampler}"));
+        properties.add(Property.from("quarkus.otel.traces.sampler.ratio", "${camel.k.telemetry.samplerRatio}"));
+        properties.add(Property.from("quarkus.otel.traces.sampler.parent-based", "${camel.k.telemetry.samplerParentBased}"));
         addCapability(runtimeSpec, catalogSpec, "telemetry", artifacts, properties, new ArrayList<>(), new ArrayList<>(), false);
 
         artifacts.clear();


### PR DESCRIPTION
Properties modification:
* propEndpoint: "quarkus.opentelemetry.tracer.exporter.otlp.endpoint" => "quarkus.otel.exporter.otlp.traces.endpoint"
* propServiceName: "quarkus.opentelemetry.tracer.resource-attributes" =>  "quarkus.otel.resource.attributes"
* propSampler: "quarkus.opentelemetry.tracer.sampler" =>  "quarkus.otel.traces.sampler"
* propSamplerRatio: "quarkus.opentelemetry.tracer.sampler.ratio" => "quarkus.otel.traces.sampler.ratio"
* propSamplerParentBased: "quarkus.opentelemetry.tracer.sampler.parent-based" => "quarkus.otel.traces.sampler.parent-based"

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(trait): Telemetry trait properties change
```
